### PR TITLE
chore: update readme and others

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,9 +2,9 @@
 
 ## Article I: Purpose
 
-1. The API Improvement Proposals (AIP) project exists to help developers and
+1. The API Extension Proposals (AEP) project exists to help developers and
    organizations build clear, consistent network APIs and clients by providing
-   an extensible set of design guidelines (AIPs) and an ecosystem of tools to
+   an extensible set of design guidelines (AEPs) and an ecosystem of tools to
    apply those rules in practice.
 2. To support this aim, the project provides and maintains tools that enrich
    the experience of developing and using APIs that conform to the project's
@@ -13,12 +13,12 @@
 
 ## Article II: Association
 
-1. The AIP project is a project of the Cloud Native Computing Foundation. As
-   such, it accepts the [CNCF Code of Conduct][0].
+1. The AEP project aims to be a project of the Cloud Native Computing
+   Foundation. As such, it accepts the [CNCF Code of Conduct][0].
 
 ## Article III: Steering Committee
 
-1. The AIP project shall be governed by a steering committee, comprising at
+1. The AEP project shall be governed by a steering committee, comprising at
    least five representatives from at least five distinct organizations.
 2. No more than one third of the committee shall represent or be employed by
    the same organization.
@@ -31,9 +31,9 @@
    to consider the addition, removal, or replacement of members.
 4. The members of the steering committee shall be maintained in a
    MAINTAINERS.md file in the
-   [primary AIP GitHub repository](https://github.com/aip-dev/aip).
+   [primary AEP GitHub repository](https://github.com/aep-dev/aep.dev).
 5. Steering committee members accept the following responsibilities:
-   1. Ownership of the charter, vision, and direction of the AIP project.
+   1. Ownership of the charter, vision, and direction of the AEP project.
    2. Regular attendance and participation at stated committee meetings.
    3. Contribution of design guidance or code as appropriate, and reviewing the
       contributions of others.
@@ -47,7 +47,7 @@
 
 ## Article IV: Source of Truth
 
-1. The AIP GitHub repositories are the source of truth for everything in the
+1. The AEP GitHub repositories are the source of truth for everything in the
    project, including both code and guidelines.
 
 ## Article V: Meetings & Voting

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,33 +1,27 @@
-# AIP Maintainers
+# AEP Maintainers
 
-This page lists all active maintainers of the aip.dev and standard. Maintainers
-have write and approval privileges to the aip.dev repository.
+This page lists all active maintainers of aep.dev. Maintainers have write and
+approval privileges to the aep-dev organization.
 
 ## Maintainers
 
-| Name                | GitHub                                           | Organization |
-| ------------------- | ------------------------------------------------ | ------------ |
-| [Yusuke Tsutsumi][] | [@toumorokoshi](https://github.com/toumorokoshi) | Google       |
-| [Mak Ahmad][]       | [@makahmad](https://github.com/makahmad)         |              |
-| Richard Frankel     | [@rofrankel](https://github.com/rofrankel)       | Roblox       |
-| Dan Hudlow          | [@hudlow](https://github.com/hudlow)             | IBM          |
-| Alfred Fuller       | [@alfus](https://github.com/alfus)               | Buf          |
-| Jeff Albert         | [@monkey-jeff](https://github.com/monkey-jeff)   | Salesforce   |
-| Mike Kistler        | [@mkistler](https://github.com/mkistler)         | Microsoft    |
-| Richard Gibson      | [@gibson042](https://github.com/gibson042)       | Algoric      |
-| [David Ebbo][]      | [@davidebbo](https://github.com/davidebbo)       | Google       |
-| [Sam Woodard][]     | [@shwoodard](https://github.com/shwoodard)       | Google       |
-| JJ Geewax           | [@jgeewax](https://github.com/jgeewax)           | Meta         |
+| Name            | GitHub                                           | Organization |
+| --------------- | ------------------------------------------------ | ------------ |
+| Yusuke Tsutsumi | [@toumorokoshi](https://github.com/toumorokoshi) | Cruise       |
+| Mak Ahmad       | [@makahmad](https://github.com/makahmad)         |              |
+| Richard Frankel | [@rofrankel](https://github.com/rofrankel)       | Roblox       |
+| Dan Hudlow      | [@hudlow](https://github.com/hudlow)             | IBM          |
+| Alfred Fuller   | [@alfus](https://github.com/alfus)               | Buf          |
+| Jeff Albert     | [@monkey-jeff](https://github.com/monkey-jeff)   | Salesforce   |
+| Mike Kistler    | [@mkistler](https://github.com/mkistler)         | Microsoft    |
+| Richard Gibson  | [@gibson042](https://github.com/gibson042)       | Algoric      |
+| JJ Geewax       | [@jgeewax](https://github.com/jgeewax)           | Meta         |
 
 ## Emiritus
 
-The following table enumerates previous maintainers of the aip.dev standard.
+The following table enumerates previous maintainers of aip.dev, the original
+style guide from which aep.dev was forked.
 
 | Name            | GitHub                                               | Organization |
 | --------------- | ---------------------------------------------------- | ------------ |
 | Luke Sneeringer | [@lukesneeringer](https://github.com/lukesneeringer) |              |
-
-[David Ebbo]: mailto:davidebbo@google.com
-[Mak Ahmad]: mailto:mak1@fb.com
-[Sam Woodard]: mailto:samwoodard@google.com
-[Yusuke Tsutsumi]: mailto:yusuketsutsumi@google.com

--- a/README.md
+++ b/README.md
@@ -1,58 +1,25 @@
-# API Improvement Proposals
+# API Extension Proposals
 
-**TL;DR:** AIPs are lots of documents on how Google does APIs.
+**NOTE**: this repository currently has a significant amount of outdated
+content. Active development and discussion is occuring in
+[aepc](https://github.com/aep-dev/aepc).
+
+Once an API specification and design pattern guide solidifies, this repository
+will be updated.
 
 ## Overview
 
-AIP stands for **API Improvement Proposal**, which is a design document
-providing high-level, concise documentation for API development. The goal is
-for these documents to serve as the source of truth for API-related
-documentation at Google and the way API teams discuss and come to consensus on
-API guidance. The program is named and styled after Python's enhancement
-proposals (PEPs) which have seemed to work pretty well over the years.
-
-### Specific areas inside Google
-
-While much of the API-related guidance is general and spans across all the
-different products at Google, we've found that some teams working in different
-areas may have different customs, styles, or guidance. To accommodate these
-historical differences, we've provided separate blocks of numbers for those
-areas where they might override or extend the more general guidance.
-
-## Getting started
-
-### New to AIPs?
-
-If you're **new to AIPs**, check out the [Frequently Asked Questions][] which
-answer some common questions about how AIPs work and what you need to know.
-
-### Want to use this in your company?
-
-If you like what you see and **want to adopt the general AIPs for your
-organization**, check out our guide on [Adopting AIPs in your company][]. This
-guide walks you through how to start using AIPs and write your own guidance
-specific to your organization.
-
-### Have an idea for an AIP?
-
-If you **have an idea for an AIP that isn't written yet** (yes, there are
-plenty!) check out [Contributing to the project][] to see how you can write
-AIPs for others to follow.
-
-[frequently asked questions]: ./aip/faq.md
-[adopting aips in your company]: ./aip/adopting.md
-[contributing to the project]: ./CONTRIBUTING.md
+See [GOVERNANCE.md](./GOVERNANCE.md).
 
 ## Learn and Connect
 
 If you'd like to get involved in the AIP community, we'd love to have you! The
 following channels of communication are available:
 
-- [The #aip channel in the CNCF Slack](https://cloud-native.slack.com/archives/C04TX46UCTV).
+- [The #aep channel in the CNCF Slack](https://cloud-native.slack.com/archives/C04TX46UCTV).
   Sign up at https://slack.cncf.io.
-- [The AIP Google Calendar, to view any upcoming meetings](https://calendar.google.com/calendar/u/0?cid=N2UzNWRkM2RmMTk0YTMyZjRmYTdjMDNhMzQ1NGUyNGJhMzY1MWU2ZjU2ODI0OGVmZTFkZGYxZTM0YTdiZWU5ZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
-  - A community meeting is also listed, subject to change but currently
-    Wednesday mornings PST.
+- [The AEP Google Calendar, to view any upcoming meetings](https://calendar.google.com/calendar/u/0?cid=N2UzNWRkM2RmMTk0YTMyZjRmYTdjMDNhMzQ1NGUyNGJhMzY1MWU2ZjU2ODI0OGVmZTFkZGYxZTM0YTdiZWU5ZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+  - A weekly project meeting is held, which anyone interested is welcome to attend!
 
 ## License
 


### PR DESCRIPTION
This repository has not had it's README
updated since aep.dev was forked.