### PR TITLE
fix: adding slugs and categories

### DIFF
--- a/aep/general/0001/aep.yaml
+++ b/aep/general/0001/aep.yaml
@@ -2,6 +2,7 @@
 id: 1
 state: reviewing
 created: 2020-10-05
+slug: purpose
 placement:
   category: meta
   order: 10

--- a/aep/general/0002/aep.yaml
+++ b/aep/general/0002/aep.yaml
@@ -2,6 +2,7 @@
 id: 2
 state: approved
 created: 2023-10-25
+slug: numbering
 placement:
   category: meta
   order: 10

--- a/aep/general/0126/aep.yaml
+++ b/aep/general/0126/aep.yaml
@@ -1,8 +1,9 @@
 ---
 id: 126
 state: approved
-slug: enums
+slug: enumerations
 created: 2019-07-24
 placement:
   category: resources
   order: 60
+redirect_from: "/enums"

--- a/aep/general/0126/aep.yaml
+++ b/aep/general/0126/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 126
 state: approved
+slug: enums
 created: 2019-07-24
 placement:
-  category: resource-design
+  category: resources
   order: 60

--- a/aep/general/0131/aep.yaml
+++ b/aep/general/0131/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 131
 state: approved
+slug: get
 created: 2019-01-22
 placement:
-  category: operations
+  category: standard-methods
   order: 10

--- a/aep/general/0132/aep.yaml
+++ b/aep/general/0132/aep.yaml
@@ -2,6 +2,7 @@
 id: 132
 state: approved
 created: 2019-01-22
+slug: list
 placement:
   category: operations
   order: 20

--- a/aep/general/0136/aep.yaml
+++ b/aep/general/0136/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 136
 state: approved
+slug: custom-methods
 created: 2019-01-25
 placement:
-  category: operations
+  category: standard-methods
   order: 100

--- a/aep/general/0141/aep.md
+++ b/aep/general/0141/aep.md
@@ -1,4 +1,4 @@
-# Quantities
+Quantities
 
 Many services need to represent a discrete quantity of items (number of bytes,
 number of miles, number of nodes, etc.).

--- a/aep/general/0141/aep.yaml
+++ b/aep/general/0141/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 141
 state: approved
+slug: quantities
 created: 2019-07-18
 placement:
   category: fields

--- a/aep/general/0142/aep.yaml
+++ b/aep/general/0142/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 142
 state: approved
+slug: time
 created: 2019-07-16
 placement:
   category: fields

--- a/aep/general/0142/aep.yaml
+++ b/aep/general/0142/aep.yaml
@@ -1,7 +1,7 @@
 ---
 id: 142
 state: approved
-slug: time
+slug: time-and-duration
 created: 2019-07-16
 placement:
   category: fields

--- a/aep/general/0144/aep.yaml
+++ b/aep/general/0144/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 144
 state: approved
+slug: arrays
 created: 2020-03-19
 placement:
   category: fields

--- a/aep/general/0145/aep.yaml
+++ b/aep/general/0145/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 145
 state: approved
+slug: ranges
 created: 2020-05-28
 placement:
   category: fields

--- a/aep/general/0151/aep.yaml
+++ b/aep/general/0151/aep.yaml
@@ -1,8 +1,9 @@
 ---
 id: 151
 state: reviewing
-slug: lro
+slug: long-running-operations
 created: 2019-07-25
 placement:
   category: standard-methods
   order: 70
+redirect_from: "/lro"

--- a/aep/general/0151/aep.yaml
+++ b/aep/general/0151/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 151
 state: reviewing
+slug: lro
 created: 2019-07-25
 placement:
-  category: operations
+  category: standard-methods
   order: 70

--- a/aep/general/0151/lro.oas.yaml
+++ b/aep/general/0151/lro.oas.yaml
@@ -22,12 +22,15 @@ components:
       properties:
         name:
           type: string
-          description: The server-assigned name, which is only unique within the same service that originally returns it.
+          description:
+            The server-assigned name, which is only unique within the same
+            service that originally returns it.
         done:
           type: boolean
           description: >-
-            If the value is false, it means the operation is still in progress. If true, the operation is completed,
-            and either response or error is available.
+            If the value is false, it means the operation is still in progress.
+            If true, the operation is completed, and either response or error
+            is available.
         error:
           $ref: '#/components/schemas/Error'
       required:

--- a/aep/general/0154/aep.yaml
+++ b/aep/general/0154/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 154
 state: approved
+slug: etag
 created: 2019-07-24
 placement:
-  category: design-patterns
+  category: operations
   order: 30

--- a/aep/general/0154/aep.yaml
+++ b/aep/general/0154/aep.yaml
@@ -1,7 +1,7 @@
 ---
 id: 154
 state: approved
-slug: etag
+slug: etags
 created: 2019-07-24
 placement:
   category: operations

--- a/aep/general/0158/aep.yaml
+++ b/aep/general/0158/aep.yaml
@@ -1,7 +1,8 @@
 ---
 id: 158
 state: approved
+slug: pagination
 created: 2019-02-18
 placement:
-  category: design-patterns
+  category: operations
   order: 60

--- a/aep/general/0164/aep.yaml
+++ b/aep/general/0164/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 164
 state: approved
+slug: soft-delete
 created: 2020-10-06
 placement:
   category: design-patterns

--- a/aep/general/0210/aep.yaml
+++ b/aep/general/0210/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 210
 state: approved
+slug: unicode
 created: 2018-08-20
 placement:
   category: design-patterns

--- a/aep/general/0211/aep.yaml
+++ b/aep/general/0211/aep.yaml
@@ -1,6 +1,7 @@
 ---
 id: 211
 state: approved
+slug: auth
 created: 2021-02-24
 placement:
   category: design-patterns

--- a/aep/general/0211/aep.yaml
+++ b/aep/general/0211/aep.yaml
@@ -1,8 +1,9 @@
 ---
 id: 211
 state: approved
-slug: auth
+slug: authorization
 created: 2021-02-24
 placement:
   category: design-patterns
   order: 115
+redirect_from: "/authz"

--- a/aep/general/scope.yaml
+++ b/aep/general/scope.yaml
@@ -1,3 +1,16 @@
 ---
 title: General
 order: 0
+categories:
+  - code: meta
+    title: Meta
+  - code: resources
+    title: Resources
+  - code: standard-methods
+    title: Standard Methods
+  - code: fields
+    title: Fields
+  - code: operations
+    title: Fields
+  - code: design-patterns
+    title: Design Patterns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aep-site-generator==0.6.7
+aep-site-generator==0.7.0


### PR DESCRIPTION
As site-generator now supports slugs and categories, adding them retroactively to all AEPs.