### PR TITLE
feat(resource-types): add resource-types

### DIFF
--- a/aep/general/0003/aep.md
+++ b/aep/general/0003/aep.md
@@ -68,8 +68,7 @@ An object upon which one or more methods can operate.
 
 ### API Resource Type
 
-The type of an object exposed via an API. It is globally unique within an
-API.
+The type of an object exposed via an API. It is globally unique within an API.
 
 ### API Service
 

--- a/aep/general/0003/aep.md
+++ b/aep/general/0003/aep.md
@@ -11,6 +11,8 @@ The following terminology **must** be used consistently throughout AEPs.
 Application Programming Interface. This can be a local interface (such as an
 SDK) or a Network API (defined below).
 
+APIs define one or more operations upon resource types.
+
 ### API Backend
 
 A set of servers and related infrastructure that implements the business logic
@@ -33,23 +35,27 @@ Examples of clients include the following:
 
 ### API Definition
 
-A well-structured representation of an API Service.
+A well-structured representation of an API.
 
 ### API Endpoint
 
-Refers to a network address that an API Service uses to handle incoming API
-Requests. One API Service may have multiple API Service Endpoints, such as
-`https://pubsub.example.com` and `https://content-pubsub.example.com`.
+Refers to a network address that an API uses to handle incoming requests. One
+API may have multiple endpoints, such as `https://pubsub.example.com` and
+`https://content-pubsub.example.com`.
 
 ### API Gateway
 
 One or more services that together provide common functionality across API
-Services, such as load balancing and authentication.
+services, such as load balancing and authentication.
 
 ### API Method
 
 An individual operation within an API. It is typically represented in Protocol
 Buffers by an `rpc` definition, or in HTTP via a `method` and a `path`.
+
+### API Name
+
+The name by which to refer to an API.
 
 ### API Request
 
@@ -58,11 +64,17 @@ logging, monitoring, and rate limiting.
 
 ### API Resource
 
-An object upon which one or more API methods operate.
+An object upon which one or more methods can operate.
 
 ### API Resource Type
 
-An API resource type represents a category of that consumes and API,
+The type of an object exposed via an API. It is globally unique within an
+API.
+
+### API Service
+
+An implementation of an API, exposing API methods on one or more network
+addresses.
 
 ### Consumer
 

--- a/aep/general/0003/aep.md
+++ b/aep/general/0003/aep.md
@@ -64,11 +64,11 @@ logging, monitoring, and rate limiting.
 
 ### API Resource
 
-An object upon which one or more methods can operate.
+An entity upon which one or more methods can operate.
 
 ### API Resource Type
 
-The type of an object exposed via an API. It is globally unique within an API.
+The type of a API resource. It is globally unique within an API.
 
 ### API Service
 

--- a/aep/general/0004/aep.md
+++ b/aep/general/0004/aep.md
@@ -17,13 +17,13 @@ APIs **must** define a resource type for each resource in the API, according to
 the following pattern: `{API Name}/{Type Name}`. The type name:
 
 - **must** Start with an uppercase letter.
-- **must** Only contain alphanumeric characters.
+- **must** Only contain ASCII alphanumeric characters.
 - **must** Be of the singular form of the noun.
 - **must** Use PascalCase (UpperCamelCase).
 - For Kubernetes, the type name **must** match the [object][] name.
 - For OpenAPI, the type name **must** match the name of the schema representing
   the object.
-- For Protobuf, the type name **must** match the name of the protobuf message.
+- For protobuf, the type name **must** match the name of the protobuf message.
 
 ### Examples
 
@@ -70,11 +70,11 @@ message Topic {
 
 #### Pattern uniqueness
 
-If multiple patterns are defined within a resource, the patterns defined must
-not overlap in the set of resource paths that they can match. In other words, a
+If multiple patterns are defined within a resource, the patterns defined **must
+not** overlap in the set of resource paths that they can match. In other words, a
 resource path may match at most one of the patterns.
 
-Therefore the following two patterns **must not** be defined within the same
+For example, the following two patterns would not be valid for the same
 resource:
 
 - `user/{user}`

--- a/aep/general/0004/aep.md
+++ b/aep/general/0004/aep.md
@@ -20,11 +20,11 @@ the following pattern: `{API Name}/{Type Name}`. The type name:
 - **must** Start with a lowercase letter.
 - **must** Be of the singular form of the noun.
 - **must** Use kebab case.
-- For Kubernetes, the type name when converted to upper camel case **must**
-  match the [object][] name.
-- For OpenAPI, the type name when converted to upper camel case **must** match
+- For Kubernetes, the type name when converted to UpperCamelCase **must** match
+  the [object][] name.
+- For OpenAPI, the type name when converted to UpperCamelCase **must** match
   the name of the schema representing the object.
-- For protobuf, the type name when converted to upper camel case **must** match
+- For protobuf, the type name when converted to UpperCamelCase **must** match
   the name of the protobuf message.
 
 ### Examples
@@ -36,7 +36,7 @@ Examples of resource types include:
 - `pubsub.example.com/subscription`
 - `spanner.example.com/database`
 - `spanner.example.com/instance`
-- `user.example.com/user-event`
+- `apis.example.com/user/user-event`
 
 ### Annotating resource types
 
@@ -121,10 +121,9 @@ resource:
 Well-defined singular and plurals of a resource enable clients to determine the
 proper name to use in code and documentation.
 
-google.aip.dev uses upper camel case for resource types, while aep.dev
-uses kebab-case. This is to enforce better consistency in the
-representation of various multipart strings, as collection identifiers use
-kebab case.
+google.aip.dev uses UpperCamelCase for resource types, while aep.dev uses
+kebab-case. This is to enforce better consistency in the representation of
+various multipart strings, as collection identifiers use kebab case.
 
 <!-- prettier-ignore-start -->
 [resource-paths]: /resource-paths

--- a/aep/general/0004/aep.md
+++ b/aep/general/0004/aep.md
@@ -83,7 +83,7 @@ For OpenAPI 3.0, use the `x-aep-resource` extension:
 
 {% endtabs %}
 
-- The `singular` field **must** match the type name.
+- The `singular` field **must** be the kebab-case singular type name.
 - The `plural` field **must** be the kebab-case plural of the singular.
 
 The `pattern` field **must** match the `pattern` rule in the following grammar,
@@ -121,8 +121,8 @@ resource:
 Well-defined singular and plurals of a resource enable clients to determine the
 proper name to use in code and documentation.
 
-google.aip.dev defines the resource type to use upper camel case, while aeps
-define the kebab-case. This is to enforce better consistency in the
+google.aip.dev uses upper camel case for resource types, while aep.dev
+uses kebab-case. This is to enforce better consistency in the
 representation of various multipart strings, as collection identifiers use
 kebab case.
 

--- a/aep/general/0004/aep.md
+++ b/aep/general/0004/aep.md
@@ -14,23 +14,25 @@ tools such as Kubernetes or GraphQL interact with APIs from multiple providers.
 ## Guidance
 
 APIs **must** define a resource type for each resource in the API, according to
-the following pattern: `{API Name}/{Type}`. The type name:
+the following pattern: `{API Name}/{Type Name}`. The type name:
 
 - **must** Start with an uppercase letter.
 - **must** Only contain alphanumeric characters.
 - **must** Be of the singular form of the noun.
 - **must** Use PascalCase (UpperCamelCase).
 - For Kubernetes, the type name **must** match the [object][] name.
+- For OpenAPI, the type name **must** match the name of the schema representing
+  the object.
 - For Protobuf, the type name **must** match the name of the protobuf message.
 
 ### Examples
 
 Examples of resource types include:
 
-- `pubsub.googleapis.com/Topic`
-- `pubsub.googleapis.com/Subscription`
-- `spanner.googleapis.com/Database`
-- `spanner.googleapis.com/Instance`
+- `pubsub.example.com/Topic`
+- `pubsub.example.com/Subscription`
+- `spanner.example.com/Database`
+- `spanner.example.com/Instance`
 - `networking.istio.io/Instance`
 
 ### Annotating resource types
@@ -68,10 +70,9 @@ message Topic {
 
 #### Pattern uniqueness
 
-When multiple patterns are defined within a resource, these patterns **must**
-be mutually unique, where uniqueness is defined as being by-character identical
-once all resource ID path segments have been removed, leaving all `/`
-separators.
+If multiple patterns are defined within a resource, the patterns defined must
+not overlap in the set of resource paths that they can match. In other words, a
+resource path may match at most one of the patterns.
 
 Therefore the following two patterns **must not** be defined within the same
 resource:
@@ -86,8 +87,8 @@ resource:
 Well-defined singular and plurals of a resource enable clients to determine the
 proper name to use in code and documentation.
 
-lowerCamelCase can be translated into other common forms of a resource path
-such as UpperCamelCase and snake_case.
+lowerCamelCase was chosen as the formatting as it can easily translated into
+other common forms of a resource path such as UpperCamelCase and snake_case.
 
 <!-- prettier-ignore-start -->
 [resource-paths]: /resource-paths

--- a/aep/general/0004/aep.md
+++ b/aep/general/0004/aep.md
@@ -64,7 +64,7 @@ message Topic {
     pattern variable representing a `Topic` resource ID is named `{topic}`.
 - Plural **must** be the lower camel case plural of the singular.
   - Pattern collection identifier segments **must** match the plural of the
-    resources, except in the case of [nested collections][].
+    resource, except in the case of [nested collections][].
 
 #### Pattern uniqueness
 

--- a/aep/general/0004/aep.yaml
+++ b/aep/general/0004/aep.yaml
@@ -1,0 +1,7 @@
+---
+id: 4
+slug: resource-types
+state: approved
+created: 2023-11-15
+placement:
+  category: resources

--- a/common-components/json_schema/x-aep-resource.yaml
+++ b/common-components/json_schema/x-aep-resource.yaml
@@ -1,0 +1,31 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://aep.dev/common-components/json_schema/x-aep-resource.yaml
+title: AEP Resource
+description: |
+  Describes a resource exposed by an API.
+type: object
+required:
+  - type
+  - singular
+  - plural
+  - pattern
+additionalProperties: false
+properties:
+  type:
+    type: string
+    description: |
+      A string that describes the resource type.
+  singular:
+    type: string
+    description: |
+      The singular of the resource.
+  plural:
+    type: string
+    description: |
+      The plural of the resource.
+  pattern:
+    description: |
+      A list of possible resource paths that are used to identify the resource.
+    type: array
+    items:
+      type: string


### PR DESCRIPTION
Porting the resource types AEP from google.aip.dev.

Specific changes:

- Rename from resource name to resource path, to be consistent with
  aeps.
- Instead of introducing new terminology within the AEP, updating
  /glossary instead.