### PR TITLE
chore: adding contributors guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,29 @@
 
 We'd love to accept your patches and contributions to this project.
 
+## Importing an AEP from google.aip.dev
+
+Currently, the project is focused on importing AIPs from
+https://google.aip.dev/. You can contribute! the process is:
+
+1. [Select an aip to adopt from the open adoption issues](https://github.com/aep-dev/aep.dev/labels/adoption).
+   1. Consider
+      [ones also with the label "good first issue"](https://github.com/aep-dev/aep.dev/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadoption).
+2. Find the original AIP, which is suffixed with the number in the issue. For
+   example https://google.aip.dev/126.
+3. Click on "view source" on the page, click on "raw", and copy the content.
+4. Create a directory for the aep, split the content in to an aep.md an
+   aep.yaml. [Example PR](https://github.com/aep-dev/aep.dev/pull/77/files).
+5. Modify content
+   1. remove any Google-isms (e.g. replace domains with example.com)
+   1. extend any proto guidance to include both OpenAPI and proto
+      representations.
+
+Some tips:
+
+- Less is more. If there's a hard disagreement about particular guidance,
+  consider filing a follow-up issue to get the agreed upon guidance merged.
+
 ## Development Environment
 
 If you are contributing AEP content (rather than code) and want to be able to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,20 +14,22 @@ or follow the step by step guide:
 1. [Select an AIP to adopt into an AEP from the open issues with the label "adoption"](https://github.com/aep-dev/aep.dev/labels/adoption).
    - Consider
      [ones also with the label "good first issue"](https://github.com/aep-dev/aep.dev/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadoption).
-2. Find the original AIP, which is suffixed with the number in the issue. For
-   example https://google.aip.dev/126.
-3. Click on "view source" on the page, click on "raw", and copy the content.
-4. Create a directory for the aep, split the content in to an aep.md an
-   aep.yaml. [Example PR](https://github.com/aep-dev/aep.dev/pull/77/files).
-5. Modify content
+1. Navigate to the
+   [GitHub Repository](https://github.com/aip-dev/google.aip.dev), and find the
+   AIP in the
+   [general directory](https://github.com/aip-dev/google.aip.dev/tree/master/aip/general).
+   Copy the raw content.
+1. Create a directory for the aep, and update the aep.yaml file to "approved".
+   [Full example PR](https://github.com/aep-dev/aep.dev/pull/77/files).
+1. Modify the content from the aip markdown and paste over the aep.md content.
    - Remove any Google-isms (e.g. replace Google domains with example.com).
    - Extend any proto-specific guidance to include both OpenAPI and proto.
      representations.
-6. Create a GitHub PR. A reviewer should be with you in 24 hours.
+1. Create a GitHub PR. A reviewer should be with you in 24 hours.
    - If a reviewer does not review within that time, please ping @rofrankel or
      @toumorokoshi.
    - Leave comments on any parts of the text that you would like to discuss.
-7. Come say hi in our various communication channels documented in the
+1. Come say hi in our various communication channels documented in the
    [README](README.md#learn-and-connect).
 
 Some tips:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,26 +4,38 @@ We'd love to accept your patches and contributions to this project.
 
 ## Importing an AEP from google.aip.dev
 
-Currently, the project is focused on importing AIPs from
-https://google.aip.dev/. You can contribute! the process is:
+Currently, the project is focused on adopting AIPs from
+https://google.aip.dev/. You can contribute!
 
-1. [Select an aip to adopt from the open adoption issues](https://github.com/aep-dev/aep.dev/labels/adoption).
-   1. Consider
-      [ones also with the label "good first issue"](https://github.com/aep-dev/aep.dev/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadoption).
+You can
+[watch the video walkthrough](https://drive.google.com/file/d/1hCBxfTJPINVUpTLnzccJy4pFXZhQQMd3/view?usp=sharing),
+or follow the step by step guide:
+
+1. [Select an AIP to adopt into an AEP from the open issues with the label "adoption"](https://github.com/aep-dev/aep.dev/labels/adoption).
+   - Consider
+     [ones also with the label "good first issue"](https://github.com/aep-dev/aep.dev/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadoption).
 2. Find the original AIP, which is suffixed with the number in the issue. For
    example https://google.aip.dev/126.
 3. Click on "view source" on the page, click on "raw", and copy the content.
 4. Create a directory for the aep, split the content in to an aep.md an
    aep.yaml. [Example PR](https://github.com/aep-dev/aep.dev/pull/77/files).
 5. Modify content
-   1. remove any Google-isms (e.g. replace domains with example.com)
-   1. extend any proto guidance to include both OpenAPI and proto
-      representations.
+   - Remove any Google-isms (e.g. replace Google domains with example.com).
+   - Extend any proto-specific guidance to include both OpenAPI and proto.
+     representations.
+6. Create a GitHub PR. A reviewer should be with you in 24 hours.
+   - If a reviewer does not review within that time, please ping @rofrankel or
+     @toumorokoshi.
+   - Leave comments on any parts of the text that you would like to discuss.
+7. Come say hi in our various communication channels documented in the
+   [README](README.md#learn-and-connect).
 
 Some tips:
 
 - Less is more. If there's a hard disagreement about particular guidance,
   consider filing a follow-up issue to get the agreed upon guidance merged.
+- Perfect is the enemy of good. Feel free to submit PRs that are mostly there,
+  and leave questions so reviewers can help address any questions or concerns.
 
 ## Development Environment
 


### PR DESCRIPTION
To help with onboarding and migration of more AEPs, adding a contributors guide.