### PR TITLE
feat: add adopting and faq

### DIFF
--- a/pages/general/adopting.md
+++ b/pages/general/adopting.md
@@ -1,0 +1,11 @@
+# Adopting AEPs for your company
+
+Currently, we encourage adoption of AEPs via having your APIs adhere to the
+guidance served at https://aep.dev.
+
+In the future, we plan to introduce a broader ecosystem of tooling including:
+
+- A forkable repository which allows for internal mirrors and
+  organization-specific guidance.
+- Client-side and server-side code generators.
+- Validators to ensure adherence to the specification.

--- a/pages/general/faq.md
+++ b/pages/general/faq.md
@@ -16,3 +16,7 @@ However, aep.dev has significant philosophical differences:
   set of core specification that should not be forked, paired with a method to
   add organization-specific guidance that does not contradict the
   specification.
+
+aep.dev also has the advantage of hindsight, which makes it possible in some
+cases to provide better guidance than google.aip.dev. (One small example:
+renaming `page_size` to `max_page_size` for requests to paginated API methods.)

--- a/pages/general/faq.md
+++ b/pages/general/faq.md
@@ -1,0 +1,18 @@
+# Frequently Asked Questions
+
+## What is the difference between aep.dev and google.aip.dev?
+
+As aep.dev is derived from [google.aip.dev](https://google.aip.dev), a lot of
+content will be familiar.
+
+However, aep.dev has significant philosophical differences:
+
+- aep.dev prioritizes broadly applicable design guidance, while google.aip.dev
+  prioritizes design guidance this best for Google, such as guidance that is
+  backwards-compatible with existing decisions at the company.
+- aep.dev is protocol-agonistic, and considers gRPC and HTTP + JSON as
+  first-class protocols for which examples and other content will be authored.
+- google.aip.dev encourages forking the guidance, while aep.dev focuses on a
+  set of core specification that should not be forked, paired with a method to
+  add organization-specific guidance that does not contradict the
+  specification.

--- a/pages/general/licensing.md
+++ b/pages/general/licensing.md
@@ -25,9 +25,7 @@ content (such as in examples) in the code of your own projects.
 
 We say "nearly everything" as there are a few simple conditions that apply.
 
-Google's trademarks and other brand features are not included in this license.
-Please see our [standard guidelines for third party use of Google brand
-features][branding] for information about this usage.
+Trademarks and other brand features are not included in this license.
 
 In some cases, a page may include content consisting of images, audio or video
 material, or a link to content on a different webpage (such as videos or slide

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aep-site-generator==0.9.1
+aep-site-generator==0.9.2


### PR DESCRIPTION
The homepage currently 404s to missing adopting and faq pages.

In addition, try to remove some Google-specific verbage.