### PR TITLE
Move AEP-UNICODE to the types category.

### DIFF
--- a/aep/general/0210/aep.yaml
+++ b/aep/general/0210/aep.yaml
@@ -4,5 +4,5 @@ state: approved
 slug: unicode
 created: 2018-08-20
 placement:
-  category: design-patterns
+  category: types
   order: 110


### PR DESCRIPTION
This may not be a perfect fit, but it seems closer than the design patterns category.

Maybe we rename the category to types-and-encoding?