### PR TITLE
reference LRO guidance (address issue #106)

### DIFF
--- a/aep/general/0131/aep.md.j2
+++ b/aep/general/0131/aep.md.j2
@@ -12,7 +12,7 @@ resource.
 
  - APIs **must** provide a get method for resources. The purpose of the get method
 is to return data from a single resource.
- - Some resources take longer to be retrieved than is reasonable for a regular API request. In this situation, the API should use a long-running operation (AEP-151).
+ - Some resources take longer to be retrieved than is reasonable for a regular API request. In this situation, the API should use a [long-running operation](/long-running-operations).
 
 ### Requests
 

--- a/aep/general/0131/aep.md.j2
+++ b/aep/general/0131/aep.md.j2
@@ -10,8 +10,9 @@ resource.
 
 ## Guidance
 
-APIs **must** provide a get method for resources. The purpose of the get method
+ - APIs **must** provide a get method for resources. The purpose of the get method
 is to return data from a single resource.
+ - Some resources take longer to be retrieved than is reasonable for a regular API request. In this situation, the API should use a long-running operation (AEP-151).
 
 ### Requests
 


### PR DESCRIPTION
hi @toumorokoshi  - here is simple PR as an example of how to ref the LRO guidance for the standard GET method. If this is ok, then go ahead an merge and I can more on another PR for the rest of the standard methods.