### PR TITLE
refactor(schemas): house cleaning

### DIFF
--- a/common-components/json_schema/decimal.yaml
+++ b/common-components/json_schema/decimal.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://example.com/product.schema.json
+$id: https://aep.dev/common-components/json_schema/decimal
 title: Decimal
 description: |
   Represents a decimal number in a form similar to scientific notation.
@@ -10,12 +10,11 @@ description: |
   33.5 million  === {"significand": 335,  "exponent": 5}
   11/8 (1.375)  === {"significand": 1375, "exponent": -3}
 
-  Note that the range of a Decmial exceeds that of a JSON `number` (double),
+  Note that the range of a Decimal exceeds that of a JSON `number` (double),
   as well as that of a `decimal64`.
 type: object
 required:
   - significand
-  - exponent
 additionalProperties: false
 properties:
   significand:
@@ -37,3 +36,16 @@ properties:
       the decmial point.
     type: integer
     format: int32
+examples:
+  - value_equals_17:
+      significand: 17
+      exponent: 0
+  - 'value_equals_-0.005':
+      significand: -5
+      exponent: -3
+  - 'value_equals_33.5_million':
+      significand: 335
+      exponent: 5
+  - 'value_equals_11/8(1.375)':
+      significand: 1375
+      exponent: -3

--- a/common-components/json_schema/money.yaml
+++ b/common-components/json_schema/money.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://example.com/product.schema.json
+$id: https://aep.dev/common-components/json_schema/money
 title: Money
 description: |
   Represents an amount of money with its currency type.
@@ -33,4 +33,14 @@ properties:
     type: string
   quantity:
     description: The quantity of currency.
-    $ref: decimal.yaml#/definitions/Decimal
+    $ref: decimal#
+examples:
+  - 'value_equals_$5_USD':
+      currency_code: 'USD'
+      quantity:
+        significand: 5
+  - 'value_equals_1.5 Bitcoin':
+      currency_code: 'X-BTC'
+      quantity:
+        significand: 15
+        exponent: -1

--- a/common-components/json_schema/x-aep-resource.yaml
+++ b/common-components/json_schema/x-aep-resource.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/common-components/json_schema/x-aep-resource.yaml
+$id: https://aep.dev/common-components/json_schema/x-aep-resource
 title: AEP Resource
 description: |
   Describes a resource exposed by an API.
@@ -27,5 +27,6 @@ properties:
     description: |
       A list of possible resource paths that are used to identify the resource.
     type: array
+    uniqueItems: true
     items:
       type: string

--- a/common-components/schemas/type/decimal.md
+++ b/common-components/schemas/type/decimal.md
@@ -8,28 +8,28 @@ point representation in order to avoid precision errors.
 A `Decimal` represents a decimal number in a form similar to scientific
 notation.
 
-It has two fields:
+It has two properties:
 
-- The `significand` field is a 64-bit integer representing the significant
+- The `significand` property is a 64-bit integer representing the significant
   digits of the number.
-- The `exponent` field is a 32-bit integer represesnting the position of the
-  deicmal point within the value of the `significand` field; it is the power of
+- The `exponent` property is a 32-bit integer representing the position of the
+  deicmal point within the value of the `significand` property; it is the power of
   ten to which `significand` should be raised.
 
   When the exponent is `0`, the value of the `Decimal` is simply the value of
   `significand`.
 
-  When the exponent is greater than 0, represents the number of trailing zeroes
+  When the exponent is greater than `0`, the value represents the number of trailing zeroes
   after the significant digits.
 
-  When the exponent is less than 0, represents how many of the significant
+  When the exponent is less than `0`, the value represents how many significant
   digits (and implicit leading zeroes, as needed) come after the decimal point.
 
 The general formula for converting a `Decimal` to its numeric value is
-`significant * 10^exponent`, where `*` represents multplication and `^`
+`significant * 10^exponent`, where `*` represents multiplication and `^`
 represents exponentiation.
 
-Note: The range of a Decmial exceeds that of a JSON `number` (double), as well
+Note: The range of a `Decimal` exceeds that of a JSON `number` (double), as well
 as that of a `decimal64`.
 
 ## Examples

--- a/common-components/schemas/type/money.md
+++ b/common-components/schemas/type/money.md
@@ -4,9 +4,9 @@ The `Money` type represents an amount of money in a specified currency.
 
 ## Schema
 
-A `Money` has two fields:
+A `Money` has two properties:
 
-- The `currency_code` field is a string containing a currency code.
+- The `currency_code` property is a string containing a currency code.
 
   The three-letter currency codes defined in the ISO 4217 standard are always
   supported.
@@ -21,7 +21,7 @@ A `Money` has two fields:
   - "X-BTC" - Potential API-defined extension for Bitcoin.
   - "X-.RBX" - Potential API-defined extension for the virtual currency Robux
 
-- The `quantity` field is a field of type [`Decimal`][], representing the
+- The `quantity` property is of type [`Decimal`][], representing the
   quantity of currency.
 
 ## Examples


### PR DESCRIPTION
add `examples` to common components

update schema uri identifiers (`$id`)

relax constraints in decimal schema for reuse in money schema

Update markdown descriptions to align vocabulary with JSON Schema

[https://aep.dev/213]  #134 


couple issues in the existing common components that I cleaned up for JSON Schema tooling and validation