### PR TITLE
LICENSE shouldn't reference developers.google.com

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,9 @@
 Except as otherwise noted, the content of this repository is licensed under the
 [Creative Commons Attribution 4.0 License][1], and code samples are licensed
-under the [Apache 2.0 License][2]. For details, see the developer.google.com
-[Site Policies][3].
+under the [Apache 2.0 License][2].
 
 [1]: https://creativecommons.org/licenses/by/4.0/
 [2]: https://www.apache.org/licenses/LICENSE-2.0
-[3]: https://developers.google.com/terms/site-policies
 
 ---
 


### PR DESCRIPTION
Since the project isn't owned by developers.google.com, we should remove the reference from the LICENSE file.