### PR TITLE
Add GA tag as a config option

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -1,0 +1,2 @@
+---
+ga_tag: GTM-NSXMVSDN


### PR DESCRIPTION
This adds a new config option for a Google Analytics tag.

This helps address https://github.com/aep-dev/site-generator/issues/14