### PR TITLE
Add AEP-193 Errors

### DIFF
--- a/aep/general/0193/aep.md.j2
+++ b/aep/general/0193/aep.md.j2
@@ -11,16 +11,20 @@ custom error handling code.
 Services **must** clearly distinguish successful responses from error
 responses.
 
+The structure of the error response **must** be consistent across all APIs of
+the service. You **should** use the error response structure below which comes
+from the Problem Details for HTTP APIs [RFC 9457].
+
 ### Structure
 
 An error response **should** contain the following fields:
 
 | Name     | Type    | Required | Description                                                                                                                                                                                                                      |
 | -------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type     | string  | Y        | A unique identifier for the type of problem detected.                                                                                                                                                                            |
+| type     | string  | Y        | A URI reference [URI] that identifies the problem type. If the type URI is a locator (e.g., those with an "http" or "https" scheme), dereferencing it SHOULD provide human-readable documentation for the problem type.          |
 | status   | integer |          | The HTTP status code that best describes the type of problem detected.                                                                                                                                                           |
-| title    | string  |          | A human-readable description of the problem. Messages are likely to be logged in plain text and should not include information about a specific occurrence. Information about specific occurrences should be part of `metadata`. |
-| detail   | string  |          | A human-readable explanation specific to this occurrence of the problem.                                                                                                                                                         |
+| title    | string  |          | A human-readable description of the problem. Messages are likely to be logged in plain text and **must not** include information about a specific occurrence nor any sensitive data like PII. Information about specific occurrences should be part of `metadata`. |
+| detail   | string  |          | A human-readable explanation specific to this occurrence of the problem. This **may** contain PII and **should not** be logged.                                                                                                                                                        |
 | instance | string  |          | A unique identifier for the specific occurrence of the problem.                                                                                                                                                                  |
 
 An error response may contain additional fields appropriate for a specific
@@ -40,8 +44,10 @@ information or ask questions to help resolve the issue.
 The error detail field
 
 - is a developer-facing, human-readable "debug message"
-- is presented in the service's native language
 - both explains the error and offers an actionable resolution to it
+
+All human-readable error details returned by the service must use the same
+language.
 
 A JSON representation of an error response might look like the following:
 
@@ -67,6 +73,10 @@ Services **must** return a [`google.rpc.Status`][Status] message when an API
 error occurs, and **must** use the canonical error codes defined in
 [`google.rpc.Code`][Code]. More information about the particular codes is
 available in the [gRPC status code documentation][].
+
+The error response structure defined above **should** be returned in the
+`details` field of the Status message. Services **should** use the
+[`aep.api.ProblemDetails`](<!-- Add link here -->) to define this field.
 
 {% endtabs %}
 
@@ -139,7 +149,7 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
-- **2024-03-21**: From from https://google.aip.dev/193
+- **2024-03-21**: Adopt from https://google.aip.dev/193
 
 <!-- prettier-ignore-start -->
 [RFC 9457]: https://datatracker.ietf.org/doc/html/rfc9457
@@ -147,4 +157,5 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
 [long-running operations]: ./0151.md
+[URI]: https://datatracker.ietf.org/doc/html/rfc3986
 <!-- prettier-ignore-end -->

--- a/aep/general/0193/aep.md.j2
+++ b/aep/general/0193/aep.md.j2
@@ -8,205 +8,101 @@ custom error handling code.
 
 ## Guidance
 
-Services **must** return a [`google.rpc.Status`][Status] message when an API
-error occurs, and **must** use the canonical error codes defined in
-[`google.rpc.Code`][Code]. More information about the particular codes is
-available in the [gRPC status code documentation][].
+Services **must** clearly distinguish successful responses from error
+responses.
 
-Error messages **should** help a reasonably technical user _understand_ and
-_resolve_ the issue, and **should not** assume that the user is an expert in
-your particular API. Additionally, error messages **must not** assume that the
-user will know anything about its underlying implementation.
+### Structure
 
-Error messages **should** be brief but actionable. Any extra information
-**should** be provided in the `details` field. If even more information is
+An error response **should** contain the following fields:
+
+| Name     | Type    | Required | Description                                                                                                                                                                                                                      |
+| -------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type     | string  | Y        | A unique identifier for the type of problem detected.                                                                                                                                                                            |
+| status   | integer |          | The HTTP status code that best describes the type of problem detected.                                                                                                                                                           |
+| title    | string  |          | A human-readable description of the problem. Messages are likely to be logged in plain text and should not include information about a specific occurrence. Information about specific occurrences should be part of `metadata`. |
+| detail   | string  |          | A human-readable explanation specific to this occurrence of the problem.                                                                                                                                                         |
+| instance | string  |          | A unique identifier for the specific occurrence of the problem.                                                                                                                                                                  |
+
+An error response may contain additional fields appropriate for a specific
+error type.
+
+The error title and detail fields **should** help a reasonably technical user
+_understand_ and _resolve_ the issue, and **should not** assume that the user
+is an expert in your particular API. Additionally, the error title and detail
+**must not** assume that the user will know anything about its underlying
+implementation.
+
+The error detail **should** be brief but actionable. Any extra information
+**should** be provided in additional properties. If even more information is
 necessary, you **should** provide a link where a reader can get more
 information or ask questions to help resolve the issue.
 
+The error detail field
 
-A JSON representation of an error response might look like the
-following:
+- is a developer-facing, human-readable "debug message"
+- is presented in the service's native language
+- both explains the error and offers an actionable resolution to it
+
+A JSON representation of an error response might look like the following:
 
 <a name="sample"></a>
 
 ```json
 {
-  "error": {
-    "code": 429,
-    "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
-    "status": "RESOURCE_EXHAUSTED",
-    "details": [
-      {
-        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
-        "reason": "RESOURCE_AVAILABILITY",
-        "domain": "compute.googleapis.com",
-        "metadata": {
-          "zone": "us-east1-a",
-          "vmType": "e2-medium",
-          "attachment": "local-ssd=3,nvidia-t4=2",
-          "zonesWithCapacity": "us-central1-f,us-central1-c"
-        }
-      },
-      {
-        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
-        "locale": "en-US",
-        "message": "An <e2-medium> VM instance with <local-ssd=3,nvidia-t4=2> is currently unavailable in the <us-east1-a> zone.\n Consider trying your request in the <us-central1-f,us-central1-c> zone(s), which currently has/have capacity to accommodate your request.\n Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation."
-      },
-      {
-        "@type": "type.googleapis.com/google.rpc.Help",
-        "links": [
-          {
-            "description": "troubleshooting documentation",
-            "url": "https://cloud.google.com/compute/docs/resource-error"
-          }
-        ]
-      }
-    ]
-  }
+  "type": "RESOURCE_EXHAUSTED",
+  "status": 429,
+  "title": "Too Many Requests",
+  "detail": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
+  "instance": "7934df3e-4b63-429b-b0f5-b8d350ec165e"
 }
 ```
 
-### Details
+{% tab oas -%}
 
-Google defines a set of [standard detail payloads][details] for error details,
-which cover most common needs for API errors. Services **should** use these
-standard details payloads when feasible.
+The media-type for an error response should be "application/problem+json".
 
-Structured details with machine-readable identifiers **must** be used if users
-will need to write code against a specific aspect of the error. Error message
-strings **may** change over time; however, if an error message does not have a
-machine-readable identifier _in addition to_ the `code` field, changing the
-error message **must** be considered a backwards-incompatible change.
+{% tab proto -%}
 
-#### ErrorInfo
+Services **must** return a [`google.rpc.Status`][Status] message when an API
+error occurs, and **must** use the canonical error codes defined in
+[`google.rpc.Code`][Code]. More information about the particular codes is
+available in the [gRPC status code documentation][].
 
-The [`ErrorInfo`][ErrorInfo] message is the required way to send a
-machine-readable identifier. All error responses **must** include an
-`ErrorInfo` payload in the `details` field. Variable information
-**should** be included in the `metadata` field on `ErrorInfo` and
-**must** be included if it appears within an error message.
-
-#### Uniqueness
-
-Each type of detail payload **must** be included at most once. For
-example, there **must not** be more than one [`BadRequest`][BadRequest]
-message in the `details` field, but there **may** be a `BadRequest` and
-a [`PreconditionFailure`][PreconditionFailure].
-
-**Note:** `ErrorInfo` represents a special case. There **must** be exactly one
-`ErrorInfo`. It is required.
-
-### Error messages
-
-For each error, the service **must** populate the `message` field on
-[`google.rpc.Status`][Status]. This error message,
-
-- is a developer-facing, human-readable "debug message"
-- is presented in the service's native language
-- both explains the error and offers an actionable resolution to it
-  ([citation](https://cloud.google.com/apis/design/errors#error_model))
-
-**Note:** Sometimes a service will elect to always present
-`Status.message` in English rather than the application's native
-language so that messages are easily searchable in common knowledge
-bases, such as StackOverflow&trade;.
-
-When introducing an error that represents a failure scenario that did
-not previously occur for the service, the payload **must** include
-`ErrorInfo` and any variables found in dynamic segments of the error
-message **must** be present in `ErrorInfo.metadata`. See, "[Dynamic
-variables](#dynamic-variables)".
-
-#### Changing error messages
-
-<a name="status-message-warning"></a>
-
-`Status.message` **may** change. However, **use extreme caution** when
-doing so.  API consumers often treat this error message as **part of the
-API contract**. Clients perform string matches on the text to
-differentiate one error for another and even parse the error message to
-extract variables from dynamic segments.
-
-There is a safer alternative. The service can chose to include an error
-message by adding [`google.rpc.LocalizedMessage`][LocalizedMessage] to
-[`Status.details`][Status details].
-
-The error message presented in `LocalizedMessage.message` **may** be the
-same as `Status.message` or it **may** be an alternate message.
-
-Reasons to present the same error message in both locations include the
-following:
-
-- The service plans to localize either immediately or in the near
-  future.  See, "[Localization](#localization)".
-- It affords clients the ability to find an error message consistently
-  in one location, `LocalizedMessaage.message`, across all methods of
-  the API Service.
-
-Reasons to present an error message in `LocalizedMessage.message` that
-differs from `Status.message` include the following:
-
-- The service requires an end-user facing error message that differs
-  from the "debug message".
-- Ongoing, iterative error message improvements are expected.
-
-When including `LocalizedMessage`, both fields, `locale` and `message`,
-**must** be populated.  If the service is to be localized, the value of
-`locale` **must** change dynamically. See,
-"[Localization](#localization)". Otherwise, `locale` **must** always
-present the service's default locale, e.g. "en-US".
-
-When adding an error message via `LocalizedMessage`, `ErrorInfo`
-**must** be introduced either before or at the same time. If there are
-dynamic segments found in the text, the values of these variables
-**must** be included in `ErrorInfo.metadata`.  See, "[Dynamic
-variables](#dynamic-variables)".
-
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo`, the
-same [concerns](#status-message-warning) regarding client misuse of
-textual error messages apply.
+{% endtabs %}
 
 #### Dynamic variables
 
-The best, actionable error messages include dynamic segments. These
-variable parts of the message are specific to a particular request.
-Consider the following example:
+The best, actionable error detail includes dynamic segments. These variable
+parts of the message are specific to a particular request. Consider the
+following example:
 
-> The Book, "The Great Gatsby", is unavailable at the Library, "Garfield
-> East". It is expected to be available again on 2199-05-13.
+> The Book, "The Great Gatsby", is unavailable at the Library, "Garfield East".
+> It is expected to be available again on 2199-05-13.
 
-The preceding error message is made actionable by the context, both that
-originates from the request, the title of the Book and the name of the
-Library, and by the information that is known only by the service, i.e.
-the expected return date of the Book.
+The preceding error detail is made actionable by the context, both that
+originates from the request, the title of the Book and the name of the Library,
+and by the information that is known only by the service, i.e. the expected
+return date of the Book.
 
-All dynamic variables found in error messages **must** also be present
-in the `map<string, string>`, `ErrorInfo.metadata` (found on the
-*required* `ErrorInfo`).  For example, the `metadata` map for the sample
-error message above will include *at least* the following key/value
-pairs:
+All dynamic variables found in error detail **must** also be present as
+additional properties of the error response
 
 ```yaml
-bookTitle: "The Great Gatsby"
-library: "Garfield East"
-expectedReturnDate: "2199-05-13"
+bookTitle: 'The Great Gatsby'
+library: 'Garfield East'
+expectedReturnDate: '2199-05-13'
 ```
 
-Dynamic variables that do not appear in an error message **may** also be
-included in `metadata` to provide additional information to the client
-to be used programmatically.
-
-Once present in `metadata`, keys **must** continue to be included in the
-map for the error payload to be backwards compatible, even if the value
-for a particular key is empty. Keys **must** be expressed as lower
-camel-case.
+Once present for a particular error type, additional properties **must**
+continue to be included in the the error response to be backwards compatible,
+even if the value for a particular property is empty.
 
 #### Localization
 
-The value of `Status.message` **should** be presented in the service's
-native language. If a localized error message is required, the service
-**must** include [`google.rpc.LocalizedMessage`][LocalizedMessage] in
-`Status.details`.
+The title and detail fields **should** be presented in the service's native
+language. If a localized detail is required, it may be included as an
+additional property in the error response, and **should** be named
+`localizedDetail`.
 
 ### Partial errors
 
@@ -221,76 +117,34 @@ because of a problem with a single entry.
 
 Methods that require partial errors **should** use [long-running operations][],
 and the method **should** put partial failure information in the metadata
-message. The errors themselves **must** still be represented with a
-[`google.rpc.Status`][Status] object.
+message. The errors themselves **must** still be represented as an error object
+as described in this AEP.
 
 ### Permission Denied
 
 If the user does not have permission to access the resource or parent,
 regardless of whether or not it exists, the service **must** error with
-`PERMISSION_DENIED` (HTTP 403). Permission **must** be checked prior to checking
-if the resource or parent exists.
+`PERMISSION_DENIED` (HTTP 403). Permission **must** be checked prior to
+checking if the resource or parent exists.
 
 If the user does have proper permission, but the requested resource or parent
 does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Rationale
 
-### Requiring ErrorInfo
-
-`ErrorInfo` is required because it further identifies an error. With
-only approximately twenty [available values][Code] for `Status.status`,
-it is difficult to disambiguate one error from another across an entire
-[API Service][API Service].
-
-Also, error messages often contain dynamic segments that express
-variable information, so there needs to be machine readable component of
-*every* error response that enables clients to use such information
-programmatically.
-
-### LocalizedMessage
-
-`LocalizedMessage` was selected as the location to present alternate
-error messages. This is desirable when clients need to display a crafted
-error message directly to end users. `LocalizedMessage` can be used with
-a static `locale`. This may seem misleading, but it allows the service
-to eventually localize without having to duplicate or move the error
-message, which would be a backwards incompatible change.
-
 ## Further reading
 
-- For which error codes to retry, see [AIP-194](https://aip.dev/194).
-- For how to retry errors in client libraries, see
-  [AIP-4221](https://aip.dev/client-libraries/4221).
+- [RFC 9457 Problem Details for HTTP APIs][RFC 9457]
+- For which error codes to retry, see [AEP-194](https://aep.dev/194).
 
 ## Changelog
 
-- **2023-05-17**: Change the recommended language for `Status.message`
-  to be the service's native language rather than English.
-- **2023-05-17**: Specify requirements for changing error messages.
-- **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
-  responses.
-- **2023-05-04**: Require uniqueness by message type for error details.
-- **2022-11-04**: Added guidance around PERMISSION_DENIED errors previously
-  found in other AIPs.
-- **2022-08-12**: Reworded/Simplified intro to add clarity to the intent.
-- **2020-01-22**: Added a reference to the [`ErrorInfo`][ErrorInfo] message.
-- **2019-10-14**: Added guidance restricting error message mutability to if
-  there is a machine-readable identifier present.
-- **2019-09-23**: Added guidance about error message strings being able to
-  change.
+- **2024-03-21**: From from https://google.aip.dev/193
 
 <!-- prettier-ignore-start -->
-[aip-4221]: ../client-libraries/4221.md
-[details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
-[ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
-[PreconditionFailure]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L139-L166
-[BadRequest]: https://github.com/googleapis/googleapis/blob/477a59d764428136ba1d857a9633c0d231de6efa/google/rpc/error_details.proto#L168-L218
-[LocalizedMessage]: https://github.com/googleapis/googleapis/blob/e9897ed945336e2dc967b439ac7b4be6d2c62640/google/rpc/error_details.proto#L275-L285
+[RFC 9457]: https://datatracker.ietf.org/doc/html/rfc9457
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
-[Status details]: https://github.com/googleapis/googleapis/blob/aeae5ea2b01ece6c0cee046ae84b881cdc62b95d/google/rpc/status.proto#L46-L48
 [long-running operations]: ./0151.md
-[API Service]: https://cloud.google.com/apis/design/glossary#api_service
 <!-- prettier-ignore-end -->

--- a/aep/general/0193/aep.md.j2
+++ b/aep/general/0193/aep.md.j2
@@ -19,13 +19,13 @@ from the Problem Details for HTTP APIs [RFC 9457].
 
 An error response **should** contain the following fields:
 
-| Name     | Type    | Required | Description                                                                                                                                                                                                                      |
-| -------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type     | string  | Y        | A URI reference [URI] that identifies the problem type. If the type URI is a locator (e.g., those with an "http" or "https" scheme), dereferencing it SHOULD provide human-readable documentation for the problem type.          |
-| status   | integer |          | The HTTP status code that best describes the type of problem detected.                                                                                                                                                           |
+| Name     | Type    | Required | Description                                                                                                                                                                                                                                                        |
+| -------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| type     | string  | Y        | A URI reference [URI] that identifies the problem type. If the type URI is a locator (e.g., those with an "http" or "https" scheme), dereferencing it SHOULD provide human-readable documentation for the problem type.                                            |
+| status   | integer |          | The HTTP status code that best describes the type of problem detected.                                                                                                                                                                                             |
 | title    | string  |          | A human-readable description of the problem. Messages are likely to be logged in plain text and **must not** include information about a specific occurrence nor any sensitive data like PII. Information about specific occurrences should be part of `metadata`. |
-| detail   | string  |          | A human-readable explanation specific to this occurrence of the problem. This **may** contain PII and **should not** be logged.                                                                                                                                                        |
-| instance | string  |          | A unique identifier for the specific occurrence of the problem.                                                                                                                                                                  |
+| detail   | string  |          | A human-readable explanation specific to this occurrence of the problem. This **may** contain PII and **should not** be logged.                                                                                                                                    |
+| instance | string  |          | A unique identifier for the specific occurrence of the problem.                                                                                                                                                                                                    |
 
 An error response may contain additional fields appropriate for a specific
 error type.
@@ -43,8 +43,10 @@ information or ask questions to help resolve the issue.
 
 The error detail field
 
-- is a developer-facing, human-readable "debug message"
-- both explains the error and offers an actionable resolution to it
+- is a developer-facing, human-readable "debug message".
+- both explains the error and offers an actionable resolution to it.
+- value may significantly change over time for the same error, and should not
+  be string-matched by any clients to determine the error.
 
 All human-readable error details returned by the service must use the same
 language.
@@ -76,7 +78,8 @@ available in the [gRPC status code documentation][].
 
 The error response structure defined above **should** be returned in the
 `details` field of the Status message. Services **should** use the
-[`aep.api.ProblemDetails`](<!-- Add link here -->) to define this field.
+[`aep.api.ProblemDetails`](https://buf.build/aep/api/docs/main:aep.api#aep.api.ProblemDetails)
+to define this field.
 
 {% endtabs %}
 

--- a/aep/general/0193/aep.md.j2
+++ b/aep/general/0193/aep.md.j2
@@ -1,5 +1,296 @@
 # Errors
 
-**Note:** This AEP has not yet been adopted. See
-[this GitHub issue](https://github.com/aep-dev/aep.dev/issues/48) for more
-information.
+Effective error communication is an important part of designing simple and
+intuitive APIs. Services returning standardized error responses enable API
+clients to construct centralized common error handling logic. This common logic
+simplifies API client applications and eliminates the need for cumbersome
+custom error handling code.
+
+## Guidance
+
+Services **must** return a [`google.rpc.Status`][Status] message when an API
+error occurs, and **must** use the canonical error codes defined in
+[`google.rpc.Code`][Code]. More information about the particular codes is
+available in the [gRPC status code documentation][].
+
+Error messages **should** help a reasonably technical user _understand_ and
+_resolve_ the issue, and **should not** assume that the user is an expert in
+your particular API. Additionally, error messages **must not** assume that the
+user will know anything about its underlying implementation.
+
+Error messages **should** be brief but actionable. Any extra information
+**should** be provided in the `details` field. If even more information is
+necessary, you **should** provide a link where a reader can get more
+information or ask questions to help resolve the issue.
+
+
+A JSON representation of an error response might look like the
+following:
+
+<a name="sample"></a>
+
+```json
+{
+  "error": {
+    "code": 429,
+    "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
+    "status": "RESOURCE_EXHAUSTED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "RESOURCE_AVAILABILITY",
+        "domain": "compute.googleapis.com",
+        "metadata": {
+          "zone": "us-east1-a",
+          "vmType": "e2-medium",
+          "attachment": "local-ssd=3,nvidia-t4=2",
+          "zonesWithCapacity": "us-central1-f,us-central1-c"
+        }
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
+        "locale": "en-US",
+        "message": "An <e2-medium> VM instance with <local-ssd=3,nvidia-t4=2> is currently unavailable in the <us-east1-a> zone.\n Consider trying your request in the <us-central1-f,us-central1-c> zone(s), which currently has/have capacity to accommodate your request.\n Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation."
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "troubleshooting documentation",
+            "url": "https://cloud.google.com/compute/docs/resource-error"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Details
+
+Google defines a set of [standard detail payloads][details] for error details,
+which cover most common needs for API errors. Services **should** use these
+standard details payloads when feasible.
+
+Structured details with machine-readable identifiers **must** be used if users
+will need to write code against a specific aspect of the error. Error message
+strings **may** change over time; however, if an error message does not have a
+machine-readable identifier _in addition to_ the `code` field, changing the
+error message **must** be considered a backwards-incompatible change.
+
+#### ErrorInfo
+
+The [`ErrorInfo`][ErrorInfo] message is the required way to send a
+machine-readable identifier. All error responses **must** include an
+`ErrorInfo` payload in the `details` field. Variable information
+**should** be included in the `metadata` field on `ErrorInfo` and
+**must** be included if it appears within an error message.
+
+#### Uniqueness
+
+Each type of detail payload **must** be included at most once. For
+example, there **must not** be more than one [`BadRequest`][BadRequest]
+message in the `details` field, but there **may** be a `BadRequest` and
+a [`PreconditionFailure`][PreconditionFailure].
+
+**Note:** `ErrorInfo` represents a special case. There **must** be exactly one
+`ErrorInfo`. It is required.
+
+### Error messages
+
+For each error, the service **must** populate the `message` field on
+[`google.rpc.Status`][Status]. This error message,
+
+- is a developer-facing, human-readable "debug message"
+- is presented in the service's native language
+- both explains the error and offers an actionable resolution to it
+  ([citation](https://cloud.google.com/apis/design/errors#error_model))
+
+**Note:** Sometimes a service will elect to always present
+`Status.message` in English rather than the application's native
+language so that messages are easily searchable in common knowledge
+bases, such as StackOverflow&trade;.
+
+When introducing an error that represents a failure scenario that did
+not previously occur for the service, the payload **must** include
+`ErrorInfo` and any variables found in dynamic segments of the error
+message **must** be present in `ErrorInfo.metadata`. See, "[Dynamic
+variables](#dynamic-variables)".
+
+#### Changing error messages
+
+<a name="status-message-warning"></a>
+
+`Status.message` **may** change. However, **use extreme caution** when
+doing so.  API consumers often treat this error message as **part of the
+API contract**. Clients perform string matches on the text to
+differentiate one error for another and even parse the error message to
+extract variables from dynamic segments.
+
+There is a safer alternative. The service can chose to include an error
+message by adding [`google.rpc.LocalizedMessage`][LocalizedMessage] to
+[`Status.details`][Status details].
+
+The error message presented in `LocalizedMessage.message` **may** be the
+same as `Status.message` or it **may** be an alternate message.
+
+Reasons to present the same error message in both locations include the
+following:
+
+- The service plans to localize either immediately or in the near
+  future.  See, "[Localization](#localization)".
+- It affords clients the ability to find an error message consistently
+  in one location, `LocalizedMessaage.message`, across all methods of
+  the API Service.
+
+Reasons to present an error message in `LocalizedMessage.message` that
+differs from `Status.message` include the following:
+
+- The service requires an end-user facing error message that differs
+  from the "debug message".
+- Ongoing, iterative error message improvements are expected.
+
+When including `LocalizedMessage`, both fields, `locale` and `message`,
+**must** be populated.  If the service is to be localized, the value of
+`locale` **must** change dynamically. See,
+"[Localization](#localization)". Otherwise, `locale` **must** always
+present the service's default locale, e.g. "en-US".
+
+When adding an error message via `LocalizedMessage`, `ErrorInfo`
+**must** be introduced either before or at the same time. If there are
+dynamic segments found in the text, the values of these variables
+**must** be included in `ErrorInfo.metadata`.  See, "[Dynamic
+variables](#dynamic-variables)".
+
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo`, the
+same [concerns](#status-message-warning) regarding client misuse of
+textual error messages apply.
+
+#### Dynamic variables
+
+The best, actionable error messages include dynamic segments. These
+variable parts of the message are specific to a particular request.
+Consider the following example:
+
+> The Book, "The Great Gatsby", is unavailable at the Library, "Garfield
+> East". It is expected to be available again on 2199-05-13.
+
+The preceding error message is made actionable by the context, both that
+originates from the request, the title of the Book and the name of the
+Library, and by the information that is known only by the service, i.e.
+the expected return date of the Book.
+
+All dynamic variables found in error messages **must** also be present
+in the `map<string, string>`, `ErrorInfo.metadata` (found on the
+*required* `ErrorInfo`).  For example, the `metadata` map for the sample
+error message above will include *at least* the following key/value
+pairs:
+
+```yaml
+bookTitle: "The Great Gatsby"
+library: "Garfield East"
+expectedReturnDate: "2199-05-13"
+```
+
+Dynamic variables that do not appear in an error message **may** also be
+included in `metadata` to provide additional information to the client
+to be used programmatically.
+
+Once present in `metadata`, keys **must** continue to be included in the
+map for the error payload to be backwards compatible, even if the value
+for a particular key is empty. Keys **must** be expressed as lower
+camel-case.
+
+#### Localization
+
+The value of `Status.message` **should** be presented in the service's
+native language. If a localized error message is required, the service
+**must** include [`google.rpc.LocalizedMessage`][LocalizedMessage] in
+`Status.details`.
+
+### Partial errors
+
+APIs **should not** support partial errors. Partial errors add significant
+complexity for users, because they usually sidestep the use of error codes, or
+move those error codes into the response message, where the user must write
+specialized error handling logic to address the problem.
+
+However, occasionally partial errors are necessary, particularly in bulk
+operations where it would be hostile to users to fail an entire large request
+because of a problem with a single entry.
+
+Methods that require partial errors **should** use [long-running operations][],
+and the method **should** put partial failure information in the metadata
+message. The errors themselves **must** still be represented with a
+[`google.rpc.Status`][Status] object.
+
+### Permission Denied
+
+If the user does not have permission to access the resource or parent,
+regardless of whether or not it exists, the service **must** error with
+`PERMISSION_DENIED` (HTTP 403). Permission **must** be checked prior to checking
+if the resource or parent exists.
+
+If the user does have proper permission, but the requested resource or parent
+does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
+
+## Rationale
+
+### Requiring ErrorInfo
+
+`ErrorInfo` is required because it further identifies an error. With
+only approximately twenty [available values][Code] for `Status.status`,
+it is difficult to disambiguate one error from another across an entire
+[API Service][API Service].
+
+Also, error messages often contain dynamic segments that express
+variable information, so there needs to be machine readable component of
+*every* error response that enables clients to use such information
+programmatically.
+
+### LocalizedMessage
+
+`LocalizedMessage` was selected as the location to present alternate
+error messages. This is desirable when clients need to display a crafted
+error message directly to end users. `LocalizedMessage` can be used with
+a static `locale`. This may seem misleading, but it allows the service
+to eventually localize without having to duplicate or move the error
+message, which would be a backwards incompatible change.
+
+## Further reading
+
+- For which error codes to retry, see [AIP-194](https://aip.dev/194).
+- For how to retry errors in client libraries, see
+  [AIP-4221](https://aip.dev/client-libraries/4221).
+
+## Changelog
+
+- **2023-05-17**: Change the recommended language for `Status.message`
+  to be the service's native language rather than English.
+- **2023-05-17**: Specify requirements for changing error messages.
+- **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
+  responses.
+- **2023-05-04**: Require uniqueness by message type for error details.
+- **2022-11-04**: Added guidance around PERMISSION_DENIED errors previously
+  found in other AIPs.
+- **2022-08-12**: Reworded/Simplified intro to add clarity to the intent.
+- **2020-01-22**: Added a reference to the [`ErrorInfo`][ErrorInfo] message.
+- **2019-10-14**: Added guidance restricting error message mutability to if
+  there is a machine-readable identifier present.
+- **2019-09-23**: Added guidance about error message strings being able to
+  change.
+
+<!-- prettier-ignore-start -->
+[aip-4221]: ../client-libraries/4221.md
+[details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+[ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
+[PreconditionFailure]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L139-L166
+[BadRequest]: https://github.com/googleapis/googleapis/blob/477a59d764428136ba1d857a9633c0d231de6efa/google/rpc/error_details.proto#L168-L218
+[LocalizedMessage]: https://github.com/googleapis/googleapis/blob/e9897ed945336e2dc967b439ac7b4be6d2c62640/google/rpc/error_details.proto#L275-L285
+[grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+[Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+[Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+[Status details]: https://github.com/googleapis/googleapis/blob/aeae5ea2b01ece6c0cee046ae84b881cdc62b95d/google/rpc/status.proto#L46-L48
+[long-running operations]: ./0151.md
+[API Service]: https://cloud.google.com/apis/design/glossary#api_service
+<!-- prettier-ignore-end -->

--- a/aep/general/0193/aep.yaml
+++ b/aep/general/0193/aep.yaml
@@ -1,7 +1,7 @@
 ---
 id: 193
-state: reviewing
+state: approved
 slug: errors
-created: 2023-01-22
+created: 2024-03-21
 placement:
-  category:
+  category: design-patterns


### PR DESCRIPTION
## 📑 Proposed changes

This PR adds AEP-193 that describes the standard structure and contents of an error response. It is significantly revised from the Google AIP-193 to adopt the HTTP standard "Problem Details" structure as defined in RFC 9547. However, I think the structure is largely compatible with the Google error response structure -- mostly differences in property names -- so I have left the proto-specific guidance from the AIP-193 in place.

I also dropped some of the details from AIP-193. In this particular AEP, I think "less is more". Let's not get bogged down in details. I think we debated details on this AEP for over a year and never got it adopted. Let's get the basics right here and leave details for later (if ever).

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.

### Additional checklist for a new AEP

- [x] A new AEP **should** be no more than two pages if printed out.
- [x] Ensure that the PR is editable by maintainers.
- [x] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [x] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
