### PR TITLE
feat(methods): add AEP-130 on methods

### DIFF
--- a/aep/general/130/aep.md.j2
+++ b/aep/general/130/aep.md.j2
@@ -53,9 +53,9 @@ If a standard method is unsuitable, then custom methods (that are mounted to a
 resource or collection) offer a lesser, but still valuable level of consistency,
 helping the user reason about the scope of the action and the object whose
 configuration is read to inform that action. Although mutative custom methods
-are not uniform enough to have a automated integration with exclusively
+are not uniform enough to have an automated integration with exclusively
 resource-oriented clients such as [Declarative clients][], they are still a pattern that
-can easily recognized by CLIs, UIs, and SDKs.
+can be easily recognized by CLIs, UIs, and SDKs.
 
 If one cannot express their APIs in a resource-oriented fashion at all, then the
 operation falls in a category where the lack of uniformity makes it difficult

--- a/aep/general/130/aep.md.j2
+++ b/aep/general/130/aep.md.j2
@@ -1,0 +1,84 @@
+# Methods
+
+An API is composed of one or more methods, which represent a specific operation
+that a service can perform on behalf of the consumer.
+
+## Guidance
+
+### Categories of Methods
+
+The following enumerates multiple categories of methods that exist, often
+grouped up under some object (e.g. collection or resource) that the method
+operates upon.
+
+| Category Name                                                                                                                                                                                                                                         | Related AIPs                                                | [Declarative client][] integration | CLI / UI integration | SDK integration |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------- | -------------------- | --------------- |
+| *Standard Methods*                                                                                                                                                                                                                                    |                                                             |                                    |                      |                 |
+| **Standard collection methods**: operate on a collection of resources (List or Create).                                                                                                                                                               | [resources], [list], [create]                               | automatable                        | automatable          | automatable     |
+| **Standard resource methods**: fetch or mutate a single resource (Get, Update, Delete).                                                                                                                                                               | [resources], [get], [update], [delete]                      | automatable                        | automatable          | automatable     |
+| **Batch resource methods**: fetch or mutate multiple resources in a collection by name.                                                                                                                                                               | [batch-get], [batch-create], [batch-update], [batch-delete] | may be used to optimize queries    | automatable          | automatable     |
+| **Aggregated list methods**: fetch or mutate multiple resources of the same type across multiple collections.                                                                                                                                         | [reading-across-collections]                                | not useful nor automatable         | automatable          | automatable     |
+| *Custom Fetch Methods*                                                                                                                                                                                                                                |                                                             |                                    |                      |                 |
+| **Custom collection fetch methods**: fetch information across a collection that cannot be expressed via a standard method.                                                                                                                            | [custom-methods]                                            | handwritten                        | automatable          | automatable     |
+| **Custom resource fetch methods**: fetch information for a single resource that cannot be expressed via a standard method.                                                                                                                            | [custom-methods]                                            | handwritten                        | automatable          | automatable     |
+| *Custom Mutation Methods*                                                                                                                                                                                                                             |                                                             |                                    |                      |                 |
+| **Backing up a resource**: storing a copy of a resource at a particular point in time.                                                                                                                                                                | [resource-revisions]                                        | unused or handwritten              | automatable          | automatable     |
+| **Restoring a resource**: setting a resource to a version from a particular point in time.                                                                                                                                                            | [resource-revisions]                                        | unused or handwritten              | automatable          | automatable     |
+| **Renaming a resource**: modify the resource's name or id while preserving configuration and data.                                                                                                                                                    | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
+| **Custom collection mutation methods**: perform an imperative operation referencing a collection that may mutate one or more resources within that collection in fashion that cannot be easily achieved by standard methods (e.g. state transitions). | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
+| **Custom resource mutation methods**: perform an imperative operation on a resource that may mutate it in a way a standard method cannot (e.g. state transitions).                                                                                    | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
+| *Misc Custom Methods*                                                                                                                                                                                                                                 |                                                             |                                    |                      |
+| **Stateless Methods**: a method that has no permanent effect on any data within the API (e.g. translating text)                                                                                                                                       | [custom-methods]                                            | unused or handwritten              | automatable          | automatable     |
+| *None of the above*                                                                                                                                                                                                                                   |                                                             |                                    |                      |                 |
+| **Streaming methods**: methods that communicate via client, server, or bi-directional streams.                                                                                                                                                        |                                                             | handwritten                        | handwritten          | automatable     |
+
+### Choosing a method category
+
+While designing a method, API authors should choose from the defined categories
+in the following order:
+
+1. Standard methods (on collections and resources)
+1. Standard batch or aggregate methods
+1. Custom methods (on collections, resources, or stateless)
+1. Streaming methods
+
+## Rationale
+
+Resource-oriented standard and custom methods are recommended first, as they can
+be expressed in the widest variety of clients (Declarative clients, CLIs, UIs, and so on), and
+offer the most uniform experience that allows users to apply their knowledge of
+one API to another.
+
+If a standard method is unsuitable, then custom methods (that are mounted to a
+resource or collection) offer a lesser, but still valuable level of consistency,
+helping the user reason about the scope of the action and the object whose
+configuration is read to inform that action. Although mutative custom methods
+are not uniform enough to have a automated integration with exclusively
+resource-oriented clients such as [Declarative clients][], they are still a pattern that
+can easily recognized by CLIs, UIs, and SDKs.
+
+If one cannot express their APIs in a resource-oriented fashion at all, then the
+operation falls in a category where the lack of uniformity makes it difficult
+for any client aside from SDKs to model the operation. This category is
+preferred last due to the fact that a user cannot rely on their knowledge of
+similar APIs, as well as the issue that integration with many clients will
+likely have to be hand-written.
+
+[batch-create]: /batch-create
+[batch-delete]: /batch-delete
+[batch-get]: /batch-get
+[batch-update]: /batch-update
+[create]: /create
+[custom-methods]: /custom-methods
+[Declarative clients]: ./0009.md#declarative-clients
+[delete]: /delete
+[get]: /get
+[list]: /list
+[update]: /update
+[reading-across-collections]: /reading-across-collections
+[resource-revisions]: /resource-revisions
+[resources]: /resources
+
+## Changelog
+
+- **2024-04-10**: Imported from https://aip.dev/130.

--- a/aep/general/130/aep.yaml
+++ b/aep/general/130/aep.yaml
@@ -1,0 +1,7 @@
+id: 130
+state: approved
+created: 2024-04-09
+slug: methods
+placement:
+  category: standard-methods
+  order: 1


### PR DESCRIPTION
## 📑 Proposed changes

Importing from https://aip.dev/130.

The main change is updating the name of AIP links to semantic names.

fixes #152.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Migrated from google.aip.dev

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.

💝 Thank you!
