### PR TITLE
Clean up AEP-157: Partial responses:

### DIFF
--- a/aep/general/0157/aep.md.j2
+++ b/aep/general/0157/aep.md.j2
@@ -7,18 +7,12 @@ needs to give the user control over which fields it sends back.
 
 APIs **may** support partial responses in one of two ways:
 
-### Field masks parameter
+### `read_mask` parameter
 
-Field masks (`google.protobuf.FieldMask`) can be used for granting the user
-fine-grained control over what fields are returned. An API **should** support
-the mask in a side channel. For example, the parameter can be specified either
-using an HTTP query parameter, an HTTP header, or a [gRPC metadata entry][].
+Field masks can be used for granting the user fine-grained control over what
+fields are returned. An API **should** support the mask as a request field
+named `read_mask`.
 
-Field masks **should not** be specified in the
-[request](./0157.md#read-masks-as-a-request-field).
-
-- The value of the field mask parameter **must** be a
-  `google.protobuf.FieldMask`.
 - The field mask parameter **must** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
@@ -27,8 +21,17 @@ Field masks **should not** be specified in the
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 
-  **Warning:** There is a known conflict between this guidance and the
-  documentation of `FieldMask` itself:
+**Note:** Changing the default value of the field mask parameter is a
+[breaking change](./backwards-compatibility#semantic-changes).
+
+{% tab proto %}
+
+- The value of the field mask parameter **must** be a
+  `google.protobuf.FieldMask`.
+
+  **Warning:** There is a known conflict between the guidance about
+  non-terminal repeated fields guidance and the documentation of `FieldMask`
+  itself:
   [google/protobuf/field_mask.proto](https://github.com/protocolbuffers/protobuf/blob/5e84a6169cf0f9716c9285c95c860bcb355dbdc1/src/google/protobuf/field_mask.proto#L85-L86)
   states that
   `A repeated field is not allowed except at the last position of a paths string.`
@@ -37,14 +40,40 @@ Field masks **should not** be specified in the
   [here](https://github.com/protocolbuffers/protobuf/issues/8547#issuecomment-2005180068).
   Consider using the view enumeration pattern described below instead instead.
 
-**Note:** Changing the default value of the field mask parameter is a
-[breaking change](./backwards-compatibility#semantic-changes).
+{% tab oas %}
+
+**Note:** OAS example not yet written.
+
+{% endtabs %}
 
 ### View enumeration
 
 Alternatively, an API **may** support partial responses with view enums. View
 enums are useful for situations where an API only wants to expose a small
 number of permutations to the user:
+
+- The enum **should** be specified as a `view` field on the request message.
+- The enum **should** be named something ending in `-View`
+- The enum **should** at minimum have values named `BASIC` and `FULL` (although
+  it **may** have values other than these).
+- The `UNSPECIFIED` value **must** be valid (not an error), and the API
+  **must** document what the unspecified value will do.
+  - For List methods, the effective default value **should** be `BASIC`.
+  - For Get methods, the effective default value **should** be either `BASIC`
+    or `FULL`.
+- APIs **may** add fields to a given view over time. APIs **must not** remove a
+  field from a given view (this is a breaking change).
+
+  **Note:** If a service requires (or might require) multiple views with
+  overlapping but distinct values, there is a potential for a namespace
+  conflict. In this situation, the service **should** nest the view enum within
+  the individual resource.
+
+**Note:** The implicit `PATH_ONLY` view described by
+[resource association via embedded resources](.association/#embedded-resources)
+**should not** be explicitly defined in the view enum.
+
+{% tab proto %}
 
 ```proto
 enum BookView {
@@ -61,31 +90,12 @@ enum BookView {
 }
 ```
 
-- The enum **should** be specified as a `view` field on the request message.
-- The enum **should** be named something ending in `-View`
-- The enum **should** at minimum have values named `BASIC` and `FULL` (although
-  it **may** have values other than these).
-- The `UNSPECIFIED` value **must** be valid (not an error), and the API
-  **must** document what the unspecified value will do.
-  - For List RPCs, the effective default value **should** be `BASIC`.
-  - For Get RPCs, the effective default value **should** be either `BASIC` or
-    `FULL`.
 - The enum **should** be defined at the top level of the proto file (as it is
   likely to be needed in multiple requests, e.g. both `Get` and `List`). See
   [enumerations](./enumerations) for more guidance on top-level enumerations.
-- APIs **may** add fields to a given view over time. APIs **must not** remove a
-  field from a given view (this is a breaking change).
 
-  **Note:** If a service requires (or might require) multiple views with
-  overlapping but distinct values, there is a potential for a namespace
-  conflict. In this situation, the service **should** nest the view enum within
-  the individual resource.
+{% tab oas %}
 
-### Read masks as a request field
+**Note:** OAS example not yet written.
 
-**Warning:** Read masks as a single field on the request message, for example:
-`google.protobuf.FieldMask read_mask` are **DEPRECATED**.
-
-<!-- prettier-ignore-start -->
-[gRPC metadata entry]: https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
-<!-- prettier-ignore-end -->
+{% endtabs %}


### PR DESCRIPTION
* Add proto/OAS tabs.
* Remove Google-specific guidance.
* Add a cross-reference to a relevant section of AEP-ASSOCIATION.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
