### PR TITLE
chore(serve.sh): add port feature

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -17,6 +17,10 @@
 #   This script runs a "development server" from Docker.
 # -----------------------------------------------------------------------------
 
+# capture the first argument as the port, defaulting to 4000
+PORT=${1:-4000}
+shift
+
 # Build the image (if and only if it is not already built).
 if [[ "$(docker images -q aep-site 2> /dev/null)" == "" ]]; then
   docker build -t aep-site .
@@ -27,8 +31,8 @@ fi
 
 # Run the image.
 docker run --rm \
-  -p 4000:4000/tcp -p 4000:4000/udp \
+  -p "${PORT}:4000/tcp" -p "${PORT}:4000/udp" \
   -p 35729:35729/tcp -p 35729:35729/udp \
-  --mount type=bind,source=`pwd`,destination=/code/,readonly \
+  --mount "type=bind,source=$(pwd),destination=/code/,readonly" \
   aep-site \
   "$@"


### PR DESCRIPTION
Sometimes there is a different service running at port 4000 locally, so it's not possible to use serve.sh.

Add a port field to allow it's customization.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
