### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Build the static site.
         run: aep-site-gen . out
       - name: Publish the static site to GitHub Pages.
-        uses: jamesives/github-pages-deploy-action@releases/v4-init
+        uses: jamesives/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: out
+          branch: gh-pages
+          folder: out


### PR DESCRIPTION
The publish workflow is broken because the release of github-pages-deploy-action on which we used to depend is now no longer a valid release.  I updated the workflow to use `V4` rather than `releases/V4-init`.