### PR TITLE
feat(revisions): adopt aep-162 revisions

### DIFF
--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -25,12 +25,8 @@ useful include:
 - Other resources depend on or descend from different revisions of a resource.
 - There is a need to represent the change of a resource over time.
 
-APIs implementing resources with revisions **should** model resource
-revisions as a subresource of the resource. Sometimes, the revisions
-collection can be a sibling collection of the resource it is a revision of.
-
-For example, a resource revisions which may have a longer lifespan than the
-parent resource, such as a database snapshot.
+APIs implementing resources with revisions **must** model resource
+revisions as a subresource of the resource.
 
 {% tab proto %}
 
@@ -48,7 +44,7 @@ message BookRevision {
     [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Other revision IDs that share the same snapshot.
-  repeated string alternate_ids = 4
+  repeated string aliases = 4
     [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 ```
@@ -128,6 +124,8 @@ Services **may** reserve specific IDs to be [aliases][alias] (e.g.
 ```
 GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
 ```
+
+If specific IDs are reserved, services **should** document those IDs.
 
 - If a `latest` ID exists, it **must** represent the most recently created
 revision. The content of `publishers/{publisher}/books/{book}/revisions/latest`

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -27,7 +27,7 @@ useful include:
 
 APIs implementing resources with revisions **should** model resource
 revisions as a subresource of the resource. Sometimes, the revisions
-collection can be sibling collection with the resource. it is a revision of.
+collection can be a sibling collection of the resource it is a revision of.
 
 For example, a resource revisions which may have a longer lifespan than the
 parent resource, such as a database snapshot.

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -105,12 +105,12 @@ creating a new revision. Specifically examples of strategies include:
 APIs **may** use any of these strategies or any other strategy. APIs **must**
 document their revision creation strategy.
 
-APIs **should** have at least one revision for their resource at any time.
+Resources that support revisions **should** always have at least one revision.
 
 ### Resource names for revisions
 
-When referring to specific revision of a resource, the subcollection name
-**must** be named `revisions`. Resource revisions have paths with the format
+When referring to the revisions of a resource, the subcollection name
+**must** be `revisions`. Resource revisions have paths with the format
 `{resource_path}/revisions/{resource_revision}`. For example:
 ```
 publishers/123/books/les-miserables/revisions/c7cfa2a8
@@ -336,7 +336,7 @@ As revisions are nested under the resource, also see [cascading delete][].
 
 ## Rationale
 
-### For the name revision
+### For the name "revision"
 
 There was significant debate about what to call this pattern, with the following
 as proposed options:

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -116,6 +116,8 @@ When referring to the revisions of a resource, the subcollection name
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 ```
 
+The resource **must** be named `{resource_singular}Revision`.
+
 ### Server-specified aliases
 
 Services **may** reserve specific IDs to be [aliases][alias] (e.g.
@@ -125,7 +127,7 @@ Services **may** reserve specific IDs to be [aliases][alias] (e.g.
 GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
 ```
 
-If specific IDs are reserved, services **should** document those IDs.
+If specific IDs are reserved, services **must** document those IDs.
 
 - If a `latest` ID exists, it **must** represent the most recently created
 revision. The content of `publishers/{publisher}/books/{book}/revisions/latest`

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -40,7 +40,7 @@ message BookRevision {
   string path = 1;
 
   // The snapshot of the book
-  Book snapshot = 2
+  Book resource = 2
     [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp that the revision was created.
@@ -66,7 +66,7 @@ message BookRevision {
         "path": {
             "type": "string"
         },
-        "snapshot": {
+        "resource": {
             "$ref": "#/definitions/Book",
             "readOnly": true,
         },
@@ -90,8 +90,8 @@ message BookRevision {
 {% endtabs %}
 
 - The resource revision **must** contain a field with a message type of the
-  parent resource, with a field name of `snapshot`.
-    - The value of `snapshot` **must** be the original resource
+  parent resource, with a field name of `resource`.
+    - The value of `resource` **must** be the original resource
       at the point in time the revision was created.
 - The resource revision **must** contain a `create_time` field (see [AIP-142][]).
 - The resource revision **may** contain a repeated field `aliases`, which would

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -75,7 +75,7 @@ message BookRevision {
             "format": "date-time",
             "readOnly": true,
         },
-        "alternate_ids": {
+        "aliases": {
             "type": "array",
             "items": {
                 "type": "string"
@@ -106,7 +106,7 @@ creating a new revision. Specifically examples of strategies include:
 - Creating a revision when important system state changes
 - Creating a revision when specifically requested
 
-APIs **may** use any of these strategies. APIs **must**
+APIs **may** use any of these strategies or any other strategy. APIs **must**
 document their revision creation strategy.
 
 APIs **should** have at least one revision for their resource at any time.
@@ -143,7 +143,7 @@ existing revision with a custom method "alias":
 
 ```proto
 
-rpc AliasBookRevision(TagBookRevisionRequest) returns (Book) {
+rpc AliasBookRevision(AliasBookRevisionRequest) returns (Book) {
   option (google.api.http) = {
     post: "/v1/{name=publishers/*/books/*/revisions/*}:alias"
     body: "*"
@@ -160,6 +160,10 @@ message AliasBookRevisionRequest {
   // The ID of the revision to alias to, e.g. `CURRENT` or a semantic
   // version.
   string alias = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // If false, this request will fail when the alias already
+  // exists.
+  bool overwrite = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 ```
 
@@ -201,8 +205,11 @@ message AliasBookRevisionRequest {
           "path": {
             "type": "string"
           },
-          "alias_id": {
+          "alias": {
             "type": "string"
+          },
+          "overwrite": {
+            "type": "boolean"
           }
         },
         "required": ["path", "alias"]
@@ -220,15 +227,15 @@ message AliasBookRevisionRequest {
     references.
 - The request message **must** have a `alias` field:
   - The field **must** be [annotated as required][aip-203].
-- If the user calls the method with an existing `alias`, the request **must**
-  succeed and the alias will be updated to refer to the provided revision. This
-  allows users to write code against a specific alias (e.g. `published`) and the
-  revision can change with no code change.
+- If the user calls the method with an existing `alias` with `overwrite` set to
+  true, the request **must** succeed and the alias will be updated to refer to the
+  provided revision. If `overwrite` is false, the request must fail with an error code
+  ALREADY_EXISTS (HTTP 409).
 
 ### Rollback
 
 A common use case for a resource with a revision history is the ability to roll
-back to a given revision. APIs that support thie behavior **should** do so with
+back to a given revision. APIs that support this behavior **should** do so with
 a `Rollback` custom method:
 
 {% tab proto %}
@@ -329,6 +336,28 @@ AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
 
 As revisions are nested under the resource, also see [cascading delete][].
 
+## Rationale
+
+### For the name revision
+
+There was significant debate about what to call this pattern, with the following
+as proposed options:
+
+- snapshots
+- revisions
+- versions
+
+Among those, revision was chosen because:
+
+- The term "version" is often used in multiple different contexts (e.g. API
+  version), and using that noun here may result in confusion during
+  conversations where it could mean one or the other.
+- The term "snapshot" is also used for snapshots of datastores, which may not
+  follow this pattern.
+- The term "revision" does not have many conflicts with terms when describing an
+  API or resource.
+
+
 ## History
 
 ### Switching from a collection extension to a subcollection
@@ -351,17 +380,6 @@ It also had several disadvantages:
 The guidance was modified ultimately to enable revisions to behave like a
 resource, which reduces users' cognitive load and allows resource-oriented
 clients to easily list, get, create, update, and delete revisions.
-
-### Using resource ID instead of tag
-
-In the previous design, revisions had a separate identifer for a revision known
-as a `tag`, that would live in a revision.
-
-Tags were effectively a shadow resource ID, requiring methods to create, get and
-filter revisions based on the value of the tag.
-
-By consolidating the concept of a tag into the revision ID, the user no longer
-needs to be familiar with a second set of retrieval and identifier methods.
 
 ## Changelog
 

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -1,5 +1,396 @@
 # Resource Revisions
 
-**Note:** This AEP has not yet been adopted. See
-[this GitHub issue](https://github.com/aep-dev/aep.dev/issues/16) for more
-information.
+Some APIs need to have resources with a revision history, where users can
+reason about the state of the resource over time. There are several reasons for
+this:
+
+- Users may want to be able to roll back to a previous revision, or diff
+  against a previous revision.
+- An API may create data which is derived in some way from a resource at a
+  given point in time. In these cases, it may be desirable to snapshot the
+  resource for reference later.
+
+**Note:** We use the word _revision_ to refer to a historical reference for a
+particular resource, and intentionally avoid the term _version_, which refers
+to the version of an API as a whole.
+
+## Guidance
+
+APIs **may** store a revision history for a resource. Examples of when it is
+useful include:
+
+- When it is valuable to expose older revisions of a resource via an API. This
+  can avoid the overhead of the customers having to write their own API to store
+  and enable retrieval of revisions.
+- Other resources depend on different revisions of a resource.
+- There is a need to represent the change of a resource over time.
+
+APIs implementing resources with a revision **should** abstract resource
+revisions as nested collection of the resource. Sometimes, the revisions
+collection can be a top level collection. Exceptions include:
+
+- If resource revisions are meant to have longer lifespan than the parent
+resource. In other words, resource revisions exist after resource deletion.
+
+{% tab proto %}
+
+```proto
+message BookRevision {
+  // The path of the book revision.
+  string path = 1;
+
+  // The snapshot of the book
+  Book snapshot = 2
+    [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp that the revision was created.
+  google.protobuf.Timestamp create_time = 3
+    [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Other revision IDs that share the same snapshot.
+  repeated string alternate_ids = 4
+    [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+```
+
+- The `message` **must** be annotated as a resource (AIP-123).
+- The `message` name **must** be named `{ResourceType}Revision`.
+
+{% tab oas %}
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string"
+        },
+        "snapshot": {
+            "$ref": "#/definitions/Book",
+            "readOnly": true,
+        },
+        "create_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true,
+        },
+        "alternate_ids": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "readOnly": true,
+        }
+    },
+    "required": ["path"],
+}
+```
+
+{% endtabs %}
+
+- The resource revision **must** contain a field with a message type of the
+  parent resource, with a field name of `snapshot`.
+    - The value of `snapshot` **must** be the configuration of the parent
+      at the point in time the revision was created.
+- The resource revision **must** contain a `create_time` field (see [AIP-142][]).
+- The resource revision **may** contain a repeated field `alternate_ids`, which would
+  contain a list of resource IDs that the revision is also known by (e.g. `latest`)
+
+### Creating Revisions
+
+Depending on the resource, different APIs may have different strategies for
+creating a new revision. Specifically examples of strategies include:
+
+- Creating a revision when there is a change to the parent resource
+- Creating a revision when important system state changes
+- Creating a revision when specifically requested
+
+APIs **may** use any of these strategies. APIs **must**
+document their revision creation strategy.
+
+### Resource names for revisions
+
+When referring to specific revision of a resource, the subcollection name
+**must** be named `revisions`. Resource revisions have paths with the format
+`{resource_name}/revisions/{revision_id}`. For example:
+```
+publishers/123/books/les-miserables/revisions/c7cfa2a8
+```
+
+### Server-specified Aliases
+
+Services **may** reserve specific IDs to be [aliases][alias] (e.g.
+`latest`). These are read-only and managed by the service.
+
+```
+GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
+```
+
+- If a `latest` ID exists, it **must** represent the most recently created
+revision. The content of `publishers/{publisher_id}/books/{book_id}/revisions/latest`
+and `publishers/{publisher_id}/books/{book_id}` can differ, as the latest revision may
+be different from the current state of the resource.
+
+### User-Specified Aliases
+
+APIs **may** provide a mechanism for users to assign an [alias][] ID to an
+existing revision with a custom method "alias":
+
+{% tab proto %}
+
+```proto
+
+rpc AliasBookRevision(TagBookRevisionRequest) returns (Book) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*/revisions/*}:alias"
+    body: "*"
+  };
+}
+
+message AliasBookRevisionRequest {
+  string path = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library.googleapis.com/BookRevision"
+    }];
+
+  // The ID of the revision to alias to, e.g. `CURRENT` or a semantic
+  // version.
+  string alias_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+```
+
+{% tab oas %}
+
+```json
+{
+  "paths": {
+    "/v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}:alias": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AliasBookRevisionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Book"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AliasBookRevisionRequest": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "alias_id": {
+            "type": "string"
+          }
+        },
+        "required": ["path", "alias_id"]
+      }
+    }
+  }
+}
+```
+
+{% endtabs %}
+
+- The request message **must** have a `path` field:
+  - The field **must** be [annotated as required][aip-203].
+  - The field **must** identify the [resource type][aip-123] that it
+    references.
+- The request message **must** have a `alias_id` field:
+  - The field **must** be [annotated as required][aip-203].
+- If the user calls the method with an existing `alias_id`, the request **must**
+  succeed and the alias will be updated to refer to the provided revision. This
+  allows users to write code against a specific alias (e.g. `published`) and the
+  revision can change with no code change.
+
+### Rollback
+
+A common use case for a resource with a revision history is the ability to roll
+back to a given revision. APIs **should** handle this with a `Rollback` custom
+method:
+
+{% tab proto %}
+
+```proto
+rpc RollbackBook(RollbackBookRequest) returns (BookRevision) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*/revisions/*}:rollback"
+    body: "*"
+  };
+}
+
+message RollbackBookRequest {
+  // The revision that the book should be rolled back to.
+  string path = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library.googleapis.com/BookRevision"
+    }];
+}
+```
+
+{% tab oas %}
+
+```json
+{
+  "paths": {
+    "/v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}:rollback": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RollbackBookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful rollback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookRevision"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RollbackBookRequest": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": ["path"]
+      }
+    }
+  }
+}
+```
+
+{% endtabs %}
+
+- The method **must** use the `POST` HTTP verb.
+- The method **should** return a resource revision.
+- The request message **must** have a `path` field, referring to the resource
+  revision whose configuration the resource should be rolled back to.
+  - The field **must** be [annotated as required][aip-203].
+  - The field **must** identify the [resource type][aip-123] that it
+    references.
+
+### Child resources
+
+Resources with a revision history **may** have child resources. If they do,
+there are two potential variants:
+
+- Child resources where each child resource is a child of the parent resource
+  as a whole.
+- Child resources where each child resource is a child of _a single revision
+  of_ the parent resource.
+
+APIs **should not** include multiple levels of resources with revisions, as
+this quickly becomes difficult to reason about.
+
+### Standard methods
+
+Any standard methods **must** implement the corresponding AIPs (AIP-131,
+AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
+
+- List methods: By default, revisions in the list response **must** be ordered
+  in reverse chronological order. User can supply `order_by` to override the
+  default behavior.
+- If the revision supports aliasing, a delete method with the resource name
+  of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
+  deleting the resource.
+
+As revisions are nested under the resource, also see [cascading delete][].
+
+## Rationale
+
+### Abstract revisions as nested collection
+
+Revisions being resources under nested collection make revisions a first class
+citizen.
+
+- Revisions can offer standard get, list, and delete methods.
+- It retains the flexibility of extending new fields to a revision in addition to
+  the resource message.
+
+### Output only resource configuration
+
+Although it was an option to have the revision take in the resource
+configuration as part of the create method, doing so would have allowed users to
+submit resource configuration for a revision that the resource was never in.
+
+`OUTPUT_ONLY` and requiring that a created revision represents the resource at
+current point in time eliminates that issue.
+
+## History
+
+### Switching from a collection extension to a subcollection
+
+In aip.dev prior to 2023-09, revisions were more like extension of an existing
+resource by using `@` symbol. List and delete revisions were custom methods on
+the resource collection. A single Get method was used to retrieve either the
+resource revision, or the resource.
+
+Its primary advantage was allowing a resource reference to seamlessly refer to
+a resource, or its revision.
+
+It also had several disadvantages:
+
+-  List revisions is a custom method (:listRevisions) on the resource collection
+-  Delete revision is a custom method on the resource collection
+-  Not visible in API discovery doc
+-  Resource ID cannot use `@`
+
+The guidance was modified ultimately to enable revisions to behave like a
+resource, which reduces the users cognitive load and allows resource-oriented
+clients to easily list, get, create, and update revisions.
+
+### Using resource ID instead of tag
+
+In the previous design, revisions had a separate identifer for a revision known
+as a `tag`, that would live in a revision.
+
+Tags were effectively a shadow resource ID, requiring methods to create, get and
+filter revisions based on the value of the tag.
+
+By consolidating the concept of a tag into the revision ID, the user no longer
+needs to be familiar with a second set of retrieval and identifier methods.
+
+## Changelog
+
+- **2024-07-10**: Imported from aip.dev.
+
+[alias]: ./0122.md#resource-id-aliases
+[cascading delete]: ./0135.md#cascading-delete
+[UUID4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -22,7 +22,7 @@ useful include:
 - When it is valuable to expose older revisions of a resource via an API. This
   can avoid the overhead of the customers having to write their own API to store
   and enable retrieval of revisions.
-- Other resources depend on different revisions of a resource.
+- Other resources depend on or descend from different revisions of a resource.
 - There is a need to represent the change of a resource over time.
 
 APIs implementing resources with revisions **should** abstract resource

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -25,12 +25,12 @@ useful include:
 - Other resources depend on or descend from different revisions of a resource.
 - There is a need to represent the change of a resource over time.
 
-APIs implementing resources with revisions **should** abstract resource
+APIs implementing resources with revisions **should** model resource
 revisions as a subresource of the resource. Sometimes, the revisions
-collection can be a top level collection. Exceptions include:
+collection can be sibling collection with the resource. it is a revision of.
 
-- If resource revisions are meant to have longer lifespan than the parent
-resource. In other words, resource revisions exist after resource deletion.
+For example, a resource revisions which may have a longer lifespan than the
+parent resource, such as a database snapshot.
 
 {% tab proto %}
 
@@ -94,7 +94,7 @@ message BookRevision {
     - The value of `snapshot` **must** be the original resource
       at the point in time the revision was created.
 - The resource revision **must** contain a `create_time` field (see [AIP-142][]).
-- The resource revision **may** contain a repeated field `alternate_ids`, which would
+- The resource revision **may** contain a repeated field `aliases`, which would
   contain a list of resource IDs that the revision is also known by (e.g. `latest`)
 
 ### Creating Revisions
@@ -213,8 +213,8 @@ message AliasBookRevisionRequest {
 {% endtabs %}
 
 - The request message **must** have a `path` field:
-  - The field **must** be [annotated as required][aip-203].
-  - The field **must** identify the [resource type][aip-123] that it
+  - The field **must** be [annotated as required](/field-behavior-documentation).
+  - The field **must** identify the [resource type](/resource-types) that it
     references.
 - The request message **must** have a `alias` field:
   - The field **must** be [annotated as required][aip-203].

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -109,6 +109,8 @@ creating a new revision. Specifically examples of strategies include:
 APIs **may** use any of these strategies. APIs **must**
 document their revision creation strategy.
 
+APIs **should** have at least one revision for their resource at any time.
+
 ### Resource names for revisions
 
 When referring to specific revision of a resource, the subcollection name
@@ -226,8 +228,8 @@ message AliasBookRevisionRequest {
 ### Rollback
 
 A common use case for a resource with a revision history is the ability to roll
-back to a given revision. APIs **should** handle this with a `Rollback` custom
-method:
+back to a given revision. APIs that support thie behavior **should** do so with
+a `Rollback` custom method:
 
 {% tab proto %}
 
@@ -308,13 +310,10 @@ message RollbackBookRequest {
 
 ### Child resources
 
-Resources with a revision history **may** have child resources. If they do,
-there are two potential variants:
-
-- Child resources where each child resource is a child of the parent resource
-  as a whole.
-- Child resources where each child resource is a child of _a single revision
-  of_ the parent resource.
+Resources with a revision history **may** have child resources. If they do, they
+**should** be a subset of the descendants of the original resource, and a given
+revision's descendants must be a subset of the descendants of the resource at
+the time the revision was created.
 
 ### Standard methods
 
@@ -329,17 +328,6 @@ AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
   deleting the resource.
 
 As revisions are nested under the resource, also see [cascading delete][].
-
-## Rationale
-
-### Output only-resource configuration
-
-Although it was an option to have the revision take in the resource
-configuration as part of the create method, doing so would have allowed users to
-submit resource configuration for a revision that the resource was never in.
-
-`OUTPUT_ONLY` and requiring that a created revision represents the resource at
-current point in time eliminates that issue.
 
 ## History
 
@@ -377,7 +365,7 @@ needs to be familiar with a second set of retrieval and identifier methods.
 
 ## Changelog
 
-- **2024-07-10**: Imported from aip.dev.
+- **2024-08-09**: Imported from aip.dev.
 
 [alias]: ./0122.md#resource-id-aliases
 [cascading delete]: ./0135.md#cascading-delete

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -16,7 +16,7 @@ to the version of an API as a whole.
 
 ## Guidance
 
-APIs **may** store a revision history for a resource. Examples of when it is
+APIs **may** expose a revision history for a resource. Examples of when it is
 useful include:
 
 - When it is valuable to expose older revisions of a resource via an API. This
@@ -25,8 +25,8 @@ useful include:
 - Other resources depend on different revisions of a resource.
 - There is a need to represent the change of a resource over time.
 
-APIs implementing resources with a revision **should** abstract resource
-revisions as nested collection of the resource. Sometimes, the revisions
+APIs implementing resources with revisions **should** abstract resource
+revisions as a subresource of the resource. Sometimes, the revisions
 collection can be a top level collection. Exceptions include:
 
 - If resource revisions are meant to have longer lifespan than the parent
@@ -91,7 +91,7 @@ message BookRevision {
 
 - The resource revision **must** contain a field with a message type of the
   parent resource, with a field name of `snapshot`.
-    - The value of `snapshot` **must** be the configuration of the parent
+    - The value of `snapshot` **must** be the original resource
       at the point in time the revision was created.
 - The resource revision **must** contain a `create_time` field (see [AIP-142][]).
 - The resource revision **may** contain a repeated field `alternate_ids`, which would
@@ -102,7 +102,7 @@ message BookRevision {
 Depending on the resource, different APIs may have different strategies for
 creating a new revision. Specifically examples of strategies include:
 
-- Creating a revision when there is a change to the parent resource
+- Creating a revision when there is a change to the resource
 - Creating a revision when important system state changes
 - Creating a revision when specifically requested
 
@@ -118,7 +118,7 @@ When referring to specific revision of a resource, the subcollection name
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 ```
 
-### Server-specified Aliases
+### Server-specified aliases
 
 Services **may** reserve specific IDs to be [aliases][alias] (e.g.
 `latest`). These are read-only and managed by the service.
@@ -132,7 +132,7 @@ revision. The content of `publishers/{publisher_id}/books/{book_id}/revisions/la
 and `publishers/{publisher_id}/books/{book_id}` can differ, as the latest revision may
 be different from the current state of the resource.
 
-### User-Specified Aliases
+### User-specified aliases
 
 APIs **may** provide a mechanism for users to assign an [alias][] ID to an
 existing revision with a custom method "alias":
@@ -216,7 +216,7 @@ message AliasBookRevisionRequest {
   - The field **must** be [annotated as required][aip-203].
   - The field **must** identify the [resource type][aip-123] that it
     references.
-- The request message **must** have a `alias_id` field:
+- The request message **must** have a `alias` field:
   - The field **must** be [annotated as required][aip-203].
 - If the user calls the method with an existing `alias_id`, the request **must**
   succeed and the alias will be updated to refer to the provided revision. This
@@ -325,9 +325,9 @@ Any standard methods **must** implement the corresponding AIPs (AIP-131,
 AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
 
 - List methods: By default, revisions in the list response **must** be ordered
-  in reverse chronological order. User can supply `order_by` to override the
+  in reverse chronological order. APIs **may** support the [`order_by`](./list#ordering) field to override the
   default behavior.
-- If the revision supports aliasing, a delete method with the resource name
+- If the revision supports aliasing, a delete method with the resource path
   of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
   deleting the resource.
 
@@ -335,16 +335,17 @@ As revisions are nested under the resource, also see [cascading delete][].
 
 ## Rationale
 
-### Abstract revisions as nested collection
+### Revisions as nested collections
 
-Revisions being resources under nested collection make revisions a first class
+Revisions being resources under nested collection make revisions a first-class
 citizen.
 
 - Revisions can offer standard get, list, and delete methods.
 - It retains the flexibility of extending new fields to a revision in addition to
   the resource message.
+- It avoids the need for "standard custom" methods like `:listRevisions`.
 
-### Output only resource configuration
+### Output only-resource configuration
 
 Although it was an option to have the revision take in the resource
 configuration as part of the create method, doing so would have allowed users to
@@ -357,7 +358,7 @@ current point in time eliminates that issue.
 
 ### Switching from a collection extension to a subcollection
 
-In aip.dev prior to 2023-09, revisions were more like extension of an existing
+In aip.dev prior to 2023-09, revisions were more like extensions of an existing
 resource by using `@` symbol. List and delete revisions were custom methods on
 the resource collection. A single Get method was used to retrieve either the
 resource revision, or the resource.
@@ -367,14 +368,14 @@ a resource, or its revision.
 
 It also had several disadvantages:
 
--  List revisions is a custom method (:listRevisions) on the resource collection
--  Delete revision is a custom method on the resource collection
--  Not visible in API discovery doc
--  Resource ID cannot use `@`
+-  List revisions is a custom method (`:listRevisions`) on the resource.
+-  Delete revision is a custom method on the resource.
+-  Not visible in API discovery documenation.
+-  Resource IDs cannot use the `@` symbol.
 
 The guidance was modified ultimately to enable revisions to behave like a
-resource, which reduces the users cognitive load and allows resource-oriented
-clients to easily list, get, create, and update revisions.
+resource, which reduces users' cognitive load and allows resource-oriented
+clients to easily list, get, create, update, and delete revisions.
 
 ### Using resource ID instead of tag
 

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -116,7 +116,7 @@ When referring to the revisions of a resource, the subcollection name
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 ```
 
-The resource **must** be named `{resource_singular}Revision`.
+The resource **must** be named `{resource_singular}Revision` (for example, `BookRevision`).
 
 ### Server-specified aliases
 

--- a/aep/general/0162/aep.md.j2
+++ b/aep/general/0162/aep.md.j2
@@ -113,7 +113,7 @@ document their revision creation strategy.
 
 When referring to specific revision of a resource, the subcollection name
 **must** be named `revisions`. Resource revisions have paths with the format
-`{resource_name}/revisions/{revision_id}`. For example:
+`{resource_path}/revisions/{resource_revision}`. For example:
 ```
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 ```
@@ -128,8 +128,8 @@ GET /v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}
 ```
 
 - If a `latest` ID exists, it **must** represent the most recently created
-revision. The content of `publishers/{publisher_id}/books/{book_id}/revisions/latest`
-and `publishers/{publisher_id}/books/{book_id}` can differ, as the latest revision may
+revision. The content of `publishers/{publisher}/books/{book}/revisions/latest`
+and `publishers/{publisher}/books/{book}` can differ, as the latest revision may
 be different from the current state of the resource.
 
 ### User-specified aliases
@@ -157,7 +157,7 @@ message AliasBookRevisionRequest {
 
   // The ID of the revision to alias to, e.g. `CURRENT` or a semantic
   // version.
-  string alias_id = 2 [(google.api.field_behavior) = REQUIRED];
+  string alias = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
 
@@ -166,7 +166,7 @@ message AliasBookRevisionRequest {
 ```json
 {
   "paths": {
-    "/v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}:alias": {
+    "/v1/publishers/{publisher_id}/books/{book}/revisions/{revision}:alias": {
       "post": {
         "requestBody": {
           "content": {
@@ -203,7 +203,7 @@ message AliasBookRevisionRequest {
             "type": "string"
           }
         },
-        "required": ["path", "alias_id"]
+        "required": ["path", "alias"]
       }
     }
   }
@@ -218,7 +218,7 @@ message AliasBookRevisionRequest {
     references.
 - The request message **must** have a `alias` field:
   - The field **must** be [annotated as required][aip-203].
-- If the user calls the method with an existing `alias_id`, the request **must**
+- If the user calls the method with an existing `alias`, the request **must**
   succeed and the alias will be updated to refer to the provided revision. This
   allows users to write code against a specific alias (e.g. `published`) and the
   revision can change with no code change.
@@ -254,7 +254,7 @@ message RollbackBookRequest {
 ```json
 {
   "paths": {
-    "/v1/publishers/{publisher_id}/books/{book_id}/revisions/{revision_id}:rollback": {
+    "/v1/publishers/{publisher}/books/{book}/revisions/{revision}:rollback": {
       "post": {
         "requestBody": {
           "content": {
@@ -316,15 +316,12 @@ there are two potential variants:
 - Child resources where each child resource is a child of _a single revision
   of_ the parent resource.
 
-APIs **should not** include multiple levels of resources with revisions, as
-this quickly becomes difficult to reason about.
-
 ### Standard methods
 
 Any standard methods **must** implement the corresponding AIPs (AIP-131,
 AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
 
-- List methods: By default, revisions in the list response **must** be ordered
+- List methods: By default, revisions in the list response **should** be ordered
   in reverse chronological order. APIs **may** support the [`order_by`](./list#ordering) field to override the
   default behavior.
 - If the revision supports aliasing, a delete method with the resource path
@@ -334,16 +331,6 @@ AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
 As revisions are nested under the resource, also see [cascading delete][].
 
 ## Rationale
-
-### Revisions as nested collections
-
-Revisions being resources under nested collection make revisions a first-class
-citizen.
-
-- Revisions can offer standard get, list, and delete methods.
-- It retains the flexibility of extending new fields to a revision in addition to
-  the resource message.
-- It avoids the need for "standard custom" methods like `:listRevisions`.
 
 ### Output only-resource configuration
 

--- a/aep/general/0162/aep.yaml
+++ b/aep/general/0162/aep.yaml
@@ -1,7 +1,7 @@
 ---
 id: 162
-state: reviewing
+state: approved
 slug: revisions
-created: 2023-01-22
+created: 2024-07-10
 placement:
   category: design-patterns


### PR DESCRIPTION
Adapted from aip.dev/162.

list of changes include:

- changing references to "name" to "path".
- minor formatting changes like consolidating proto examples so we can minimize the proto/openapi tabs.
- removed some sections from rationale that spoke to aip.dev more than aeps, and didn't provide valuable context (like the existence of "tag" in older versions of the pattern).
- added openapi schemas.


fixes #16.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [x] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [x] A new AEP **should** be no more than two pages if printed out.
- [x] Ensure that the PR is editable by maintainers.
- [x] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [x] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
