### PR TITLE
Create AEP-204: Oneofs.

### DIFF
--- a/aep/general/0204/aep.md.j2
+++ b/aep/general/0204/aep.md.j2
@@ -1,0 +1,67 @@
+# Oneofs
+
+Multiple IDLs have a concept called "oneof". For example, in protobuf, a
+`oneof` specifies that a set of fields within a message are mutually exclusive
+(i.e. at most one field can be set). In OAS 3, `oneOf` specifies that the value
+of a _single_ field must match _exactly one_ of a set of schemas.
+
+In order to smooth over such discrepancies, this AEP defines a generic `oneof`
+concept; when other AEPs refer to `oneof` in a generic context (i.e. outside
+IDL-specific sections or tabs), they are using this definition:
+
+- A `oneof` is a set of fields within a message that are mutually exclusive.
+  _At most one_ field can be set at a time.
+- If the `oneof` is required, that means that _exactly one_ field must be set.
+
+## protobuf
+
+Protobuf APIs **must** use the built-in `oneof` feature. In order to specify
+that a `oneof` is required, they **should** use the `aep.api.OneofBehavior`
+extension:
+
+```proto
+import "aep/api/oneof_behavior.proto";
+
+message Book {
+  // ...
+
+  // The author of the book.
+  oneof author {
+    // The individual author of a book.
+    string individual_author = 1 [(google.api.resource_reference) = {
+      type: "library.example.com/Author",
+    }];
+
+    // The organization that authored a book.
+    string organization_author = 2 [(google.api.resource_reference) = {
+      type: "library.example.com/Organization",
+    }];
+  } [(aep.api.oneof_behavior) = {required: true}];
+}
+```
+
+## OAS
+
+OAS 3's `oneOf` does not represent the same concept as a generic AEP `oneof`.
+Therefore, while APIs **may** use OAS `oneOf` when otherwise applicable, in
+order to specify an AEP `oneof`, they **should** use the [`x-aep-oneof`][]
+extension:
+
+```yaml
+components:
+  schemas:
+    Book:
+      type: object
+      properties:
+        individual_author: { type: string }
+        organization_author: { type: string }
+        x-aep-oneof:
+          name: owner
+          properties: [individual_author, organization_author]
+          required: true
+```
+
+<!-- prettier-ignore-start -->
+[`aep.api.OneofBehavior`]: https://buf.build/aep/api/docs/main:aep.api#aep.api.OneofBehavior
+[`x-aep-oneof`]: https://github.com/aep-dev/aep/tree/main/json_schema/oneof.yaml
+<!-- prettier-ignore-end -->

--- a/aep/general/0204/aep.yaml
+++ b/aep/general/0204/aep.yaml
@@ -1,0 +1,7 @@
+---
+id: 204
+state: approved
+slug: oneofs
+created: 2024-07-29
+placement:
+  category: design-patterns


### PR DESCRIPTION
Creates an AEP that defines generic, IDL-agnostic `oneof` behavior.

This uses the common components defined in https://github.com/aep-dev/aep/pull/16.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [x] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [x] A new AEP **should** be no more than two pages if printed out.
- [x] Ensure that the PR is editable by maintainers.
- [x] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [x] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
