### PR TITLE
fix(purpose): link to maintainers instead of hardcode

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ approval privileges to the aep-dev organization.
 | Alfred Fuller   | [@alfus](https://github.com/alfus)               | Buf          |
 | Alex Stephen    | [@rambleraptor](https://github.com/rambleraptor) | Google       |
 | Dan Hudlow      | [@hudlow](https://github.com/hudlow)             | IBM          |
-| Hong Zhang      | [@wora](https://github.com/wora)                 | DataBricks   |
+| Hong Zhang      | [@wora](https://github.com/wora)                 | Databricks   |
 | Mike Kistler    | [@mkistler](https://github.com/mkistler)         | Microsoft    |
 | Mak Ahmad       | [@makahmad](https://github.com/makahmad)         |              |
 | Marsh Gardiner  | [@earth2marsh](https://github.com/earth2marsh)   |              |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,6 @@ approval privileges to the aep-dev organization.
 | Alfred Fuller   | [@alfus](https://github.com/alfus)               | Buf          |
 | Alex Stephen    | [@rambleraptor](https://github.com/rambleraptor) | Google       |
 | Dan Hudlow      | [@hudlow](https://github.com/hudlow)             | IBM          |
-| Hong Zhang      | [@wora](https://github.com/wora)                 | Databricks   |
 | Mike Kistler    | [@mkistler](https://github.com/mkistler)         | Microsoft    |
 | Mak Ahmad       | [@makahmad](https://github.com/makahmad)         |              |
 | Marsh Gardiner  | [@earth2marsh](https://github.com/earth2marsh)   |              |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,9 +8,9 @@ approval privileges to the aep-dev organization.
 | Name            | GitHub                                           | Organization |
 | --------------- | ------------------------------------------------ | ------------ |
 | Alfred Fuller   | [@alfus](https://github.com/alfus)               | Buf          |
-| Jeff Albert     | [@monkey-jeff](https://github.com/monkey-jeff)   | Salesforce   |
-| JJ Geewax       | [@jgeewax](https://github.com/jgeewax)           | Meta         |
+| Alex Stephen    | [@rambleraptor](https://github.com/rambleraptor) | Google       |
 | Dan Hudlow      | [@hudlow](https://github.com/hudlow)             | IBM          |
+| Hong Zhang      | [@wora](https://github.com/wora)                 | DataBricks   |
 | Mike Kistler    | [@mkistler](https://github.com/mkistler)         | Microsoft    |
 | Mak Ahmad       | [@makahmad](https://github.com/makahmad)         |              |
 | Marsh Gardiner  | [@earth2marsh](https://github.com/earth2marsh)   |              |
@@ -26,3 +26,5 @@ style guide from which aep.dev was forked.
 | Name            | GitHub                                               | Organization |
 | --------------- | ---------------------------------------------------- | ------------ |
 | Luke Sneeringer | [@lukesneeringer](https://github.com/lukesneeringer) |              |
+| Jeff Albert     | [@monkey-jeff](https://github.com/monkey-jeff)       | Salesforce   |
+| JJ Geewax       | [@jgeewax](https://github.com/jgeewax)               | Meta         |

--- a/aep/general/0001/aep.md.j2
+++ b/aep/general/0001/aep.md.j2
@@ -44,12 +44,9 @@ and that we largely work on the basis of consensus. However, a limited number
 of designated approvers is necessary, and these committee members will be
 approvers for each AEP on [aep.dev][].
 
-The technical steering committee membership is currently:
-
-- Antoine Boyer (@tinnou), Netflix
-- Ross Hamilton (@rhamiltonsf), Salesforce
-- Mike Kistler (@mkistler), IBM
-- Luke Sneeringer (@lukesneeringer), Google
+See
+[MAINTAINERS.md](https://github.com/aep-dev/aep.dev/blob/main/MAINTAINERS.md)
+for the current committee list (known as maintainers in the document).
 
 The committee is also responsible for the administrative and editorial aspects
 of shepherding AEPs and managing the AEP pipeline and workflow. They approve


### PR DESCRIPTION
The technical steering committe is outdated. Link it to the more visible and current MAINTAINERS.md.


## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

