### PR TITLE
Add component mandate for OAS resources

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -64,19 +64,25 @@ message Topic {
 
 {% tab oas %}
 
-For OpenAPI 3.0, use the `x-aep-resource` extension:
+For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the `x-aep-resource` extension:
 
 ```json
 {
-  "type": "object",
-  "x-aep-resource": {
-    "singular": "user-event",
-    "plural": "user-events",
-    "patterns": [
-      "projects/{project}/user-events/{user-event}",
-      "folder/{folder}/user-events/{user-event}",
-      "users/{user}/events/{user-event}"
-    ]
+  "components": {
+    "schemas": {
+      "UserEvent": {
+        "type": "object",
+        "x-aep-resource": {
+          "singular": "user-event",
+          "plural": "user-events",
+          "patterns": [
+            "projects/{project}/user-events/{user-event}",
+            "folder/{folder}/user-events/{user-event}",
+            "users/{user}/events/{user-event}"
+          ]
+        }
+      }
+    }
   }
 }
 ```

--- a/aep/general/0131/aep.md.j2
+++ b/aep/general/0131/aep.md.j2
@@ -117,7 +117,7 @@ metadata:
 - The `operationId` **must** begin with the word `get`. The remainder of the
   `operationId` **should** be the singular form of the resource type's name.
 - The response content **must** be the resource itself. For example:
-  `#/components/schemas/Book`
+  `#/components/schemas/Book`. The response **must** reference a schema with a `x-aep-resource` extension.
 - The URI **should** contain a variable for each individual ID in the resource
   hierarchy.
   - The path parameter for all resource IDs **must** be in the form

--- a/aep/general/0131/get.oas.yaml
+++ b/aep/general/0131/get.oas.yaml
@@ -31,6 +31,10 @@ components:
           description: |
             The name of the book.
             Format: publishers/{publisher}/books/{book}
+        publisher:
+          type: string
+          description: |
+            The name of the publisher.
         isbn:
           type: string
           description: |

--- a/aep/general/0131/get.oas.yaml
+++ b/aep/general/0131/get.oas.yaml
@@ -18,6 +18,12 @@ paths:
 components:
   schema:
     Book:
+      type: object
+      x-aep-resource:
+        singular: book
+        plural: books
+        patterns:
+          - "publishers/{publisher}/books/{book}"
       description: A representation of a single book.
       properties:
         name:

--- a/aep/general/0131/get.oas.yaml
+++ b/aep/general/0131/get.oas.yaml
@@ -23,7 +23,7 @@ components:
         singular: book
         plural: books
         patterns:
-          - "publishers/{publisher}/books/{book}"
+          - 'publishers/{publisher}/books/{book}'
       description: A representation of a single book.
       properties:
         name:

--- a/aep/general/0141/aep.md.j2
+++ b/aep/general/0141/aep.md.j2
@@ -1,4 +1,4 @@
-Quantities
+# Quantities
 
 Many services need to represent a discrete quantity of items (number of bytes,
 number of miles, number of nodes, etc.).


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

This changes our OAS guidance to ensure that the GET method returns only a schema that is annoted with `x-aep-resource`. It also changes our guidance on resource types to show that there's an expectation that all resources have a corresponding OAS component with `x-aep-resource`


## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

### Additional checklist for a new AEP

<!-- delete if this is not a new AEP -->

- [x] A new AEP **should** be no more than two pages if printed out.
- [x] Ensure that the PR is editable by maintainers.
- [x] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [x] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

💝 Thank you!
