### PR TITLE
Fix deadlinks

### DIFF
--- a/aep/general/0005/aep.md.j2
+++ b/aep/general/0005/aep.md.j2
@@ -66,7 +66,11 @@ See the following AEPs to learn more about resource-oriented design:
 
 - [resource-oriented design][AEP-121]
 - [resource paths][AEP-122]
-- [resource types][AEP-123]
+- [resource types][AEP-4]
+
+[aep-121]: ./0121.md
+[aep-122]: ./0122.md
+[aep-4]: ./0004.md
 
 ## Identify standard operations
 
@@ -78,13 +82,24 @@ Ideally all five standard methods should be exposed for every resource.
 
 See the following AEPs to learn more about the standard methods:
 
-- [AEP-131][]
+- [Get][AEP-131]
+- [List][AEP-132]
+- [Create][AEP-133]
+- [Update][AEP-134]
+- [Delete][AEP-135]
+
+[aep-131]: ./0131.md
+[aep-132]: ./0132.md
+[aep-133]: ./0133.md
+[aep-134]: ./0134.md
+[aep-135]: ./0135.md
+
 
 ## Identify custom operations
 
 To accomplish some of the user journeys, resources may need to support
-operations other than [Create][AEP-133], [Update][AEP-134], [AEP-135][Delete],
-[AEP-131][Get], and [AEP-132][List] them. Some examples include:
+operations other than [Create][AEP-133], [Update][AEP-134], [Delete][AEP-135],
+[Get][AEP-131], and [List][AEP-132] them. Some examples include:
 
 - restarting a virtual machine
 - triggering a CI build

--- a/aep/general/0008/aep.md.j2
+++ b/aep/general/0008/aep.md.j2
@@ -28,7 +28,7 @@ clients or their authors, including but not limited to:
 - Command line interfaces for exploration and simple automation.
 - Custom controllers (e.g. auto-scalers) which poll live state and adjust
   resource configuration accordingly.
-- [IaC][] clients for orchestration and automation of multiple resources.
+- [Declarative clients][] for orchestration and automation of multiple resources.
 - Recommendation tools which provide guidance on which APIs are useful for
   specific use cases, and how to use them.
 - SDKs to interact with an API from a programming language, often used heavily
@@ -250,8 +250,7 @@ API guidance must in turn consider the impact broadly across these clients.
 <!-- Links -->
 
 [aep-1]: ./0001.md
-[Infrastructure as Code]: ./0009.md#iac
-[IaC]: ./0009.md#iac
+[Declarative clients]: ./0003.md#declarative-clients
 [OpenAPI]: https://www.openapis.org/
 [protocol buffers]: https://developers.google.com/protocol-buffers/
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt

--- a/aep/general/0009/aep.md.j2
+++ b/aep/general/0009/aep.md.j2
@@ -1,5 +1,0 @@
-# Glossary
-
-**Note:** This AEP has not yet been adopted. See
-[this GitHub issue](https://github.com/aep-dev/aep.dev/issues/33) for more
-information.

--- a/aep/general/0122/aep.md.j2
+++ b/aep/general/0122/aep.md.j2
@@ -178,7 +178,7 @@ and the full resource path does not change between these.
 When defining a resource, the first field **should** be the resource path,
 which **must** be of type `string` and **must** be called `path` for the
 resource path. The message **should** include a `google.api.resource`
-annotation declaring the type (see [AEP-123][] for more on this).
+annotation declaring the type (see [AEP-4][] for more on this).
 
 ```proto
 // A representation of a book in the library.
@@ -201,7 +201,7 @@ When defining a method that retrieves or acts on an already-existing resource
 **should** be the resource path, which **must** be of type `string` and
 **must** be called `path` for the resource path. The field **should** also be
 annotated with the `google.api.resource_reference` annotation, referencing the
-resource type ([AEP-123][]).
+resource type ([AEP-4][]).
 
 ```proto
 // Request message for ArchiveBook
@@ -222,7 +222,7 @@ string path = 1 [
 other use cases, either use a different term or prepend an adjective (for
 example: `file_path`).
 
-[aep-123]: ./0123.md
+[aep-4]: ./0004.md
 
 ### Fields representing a resource's parent
 
@@ -231,7 +231,7 @@ resource to a collection (such as `ListBooks` or `CreateBook`), the first field
 of the request message **should** be of type `string` and **should** be called
 `parent` for the resource path of the collection. The `parent` field **should**
 also be annotated with the `google.api.resource_reference` annotation,
-referencing the parent's resource type ([AEP-123][]).
+referencing the parent's resource type ([AEP-4][]).
 
 ```proto
 // Request message for ListBooks.
@@ -316,7 +316,7 @@ alone is strictly necessary, the field **should** use an `_id` suffix (e.g.
 
 - For evolving resource paths over time, see
   [AEP-180](./0180.md#changing-resource-paths).
-- For resource types, see [AEP-123][].
+- For resource types, see AEP-4.
 
 <!-- prettier-ignore-start -->
 [protovalidate]: https://github.com/bufbuild/protovalidate

--- a/aep/general/0131/aep.md.j2
+++ b/aep/general/0131/aep.md.j2
@@ -95,7 +95,7 @@ Get operations also implement a common request message pattern:
 
 - A resource path field **must** be included. It **should** be called `path`.
   - The field **should** be annotated as `REQUIRED`.
-  - The field **should** identify the [resource type][aep-123] that it
+  - The field **should** identify the [resource type][aep-4] that it
     references.
 - The comment for the `path` field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
@@ -106,6 +106,8 @@ Get operations also implement a common request message pattern:
 variable in the `google.api.http` annotation on the RPC. This causes the `path`
 field in the request to be populated based on the value in the URL when the
 REST/JSON interface is used.
+
+[aep-4]: ./0004.md
 
 {% tab oas %}
 
@@ -125,7 +127,3 @@ metadata:
     ID of parent resources **must** end with `Id`.
 
 {% endtabs %}
-
-<!-- prettier-ignore-start -->
-[aep-123]: ./0123.md
-<!-- prettier-ignore-end -->

--- a/aep/general/0133/aep.md.j2
+++ b/aep/general/0133/aep.md.j2
@@ -236,6 +236,6 @@ path and use it in references from other resources.
 [management plane]: ./0111.md#management-plane
 [errors]: ./0193.md
 [field_behavior]: ./203.md
-[Declarative clients]: ./0009.md#declarative-clients
+[Declarative clients]: ./0003.md#declarative-clients
 [permission-denied]: ./0193.md#permission-denied
 [strong consistency]: ./0121.md#strong-consistency

--- a/aep/general/0133/aep.md.j2
+++ b/aep/general/0133/aep.md.j2
@@ -106,7 +106,7 @@ message CreateBookRequest {
 - A `parent` field **must** be included unless the resource being created is a
   top-level resource. It **should** be called `parent`.
   - The field **should** be [annotated as `REQUIRED`][aep-203].
-  - The field **must** identify the [resource type][aep-123] of the resource
+  - The field **must** identify the [resource type][aep-4] of the resource
     being created.
 
 {% tab oas %}
@@ -228,7 +228,7 @@ path and use it in references from other resources.
 
 [aep-121]: ./0121.md
 [aep-122]: ./0122.md
-[aep-123]: ./0123.md
+[aep-4]: ./0004.md
 [aep-155]: ./0155.md
 [aep-203]: ./0203.md
 [aep-210]: ./0210.md

--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -90,12 +90,12 @@ message UpdateBookRequest {
 
 - A `path` field **must** be included.
   - The field **must** be [annotated as required](/field-behavior-documentation).
-  - The field **must** identify the [resource type](/resource-types) that it
+  - The field **must** identify the [resource type][aep-4] that it
     references.
 - The request message field for the resource **must** map to the `PATCH` body.
 - The request message field for the resource **should** be [annotated as
   required][aep-203].
-  - The field **must** identify the [resource type][aep-123] of the resource
+  - The field **must** identify the [resource type][aep-4] of the resource
     being updated.
 - If partial resource update is supported, a field mask **must** be included.
   It **must** be of type `google.protobuf.FieldMask`, and it **must** be called
@@ -303,6 +303,7 @@ resource does not exist, the service **must** error with `NOT_FOUND` (HTTP 404)
 unless `allow_missing` is set to `true`.
 
 <!-- prettier-ignore-start -->
+[aep-4]: ./0004.md
 [aep-121]: ./0121.md
 [aep-128]: ./0128.md
 [aep-203]: ./0203.md

--- a/aep/general/0134/aep.md.j2
+++ b/aep/general/0134/aep.md.j2
@@ -160,8 +160,8 @@ would wipe out data because the previous version did not know about it.
 ### Long-running update
 
 Some resources take longer to update a resource than is reasonable for a
-regular API request. In this situation, the API **should** use a long-running
-operation (AIP-151) instead:
+regular API request. In this situation, the API **should** use a [long-running
+operation][AEP-151] instead:
 
 - The response type **must** be set to the resource (what the return type would
   be if the method were not long-running).
@@ -306,6 +306,7 @@ unless `allow_missing` is set to `true`.
 [aep-4]: ./0004.md
 [aep-121]: ./0121.md
 [aep-128]: ./0128.md
+[aep-151]: ./0151.md
 [aep-203]: ./0203.md
 [create]: ./0133.md
 [errors]: ./0193.md

--- a/aep/general/0135/aep.md.j2
+++ b/aep/general/0135/aep.md.j2
@@ -95,7 +95,7 @@ message DeleteBookRequest {
 
 - A `path` field **must** be included. It **should** be called `path`.
   - The field **should** be [annotated as required][aep-203].
-  - The field **must** identify the [resource type][aep-123] that it
+  - The field **must** identify the [resource type][aep-4] that it
     references.
 - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
@@ -219,7 +219,7 @@ exist, the service **must** error with `404 Not found` (`NOT_FOUND`).
 - **2024-02-11**: From from https://google.aip.dev/135
 
 <!-- prettier-ignore-start -->
-[aep-123]: ./0123.md
+[aep-4]: ./0004.md
 [aep-128]: ./0128.md
 [aep-131]: ./0131.md
 [aep-132]: ./0132.md

--- a/aep/general/0144/aep.md.j2
+++ b/aep/general/0144/aep.md.j2
@@ -147,7 +147,7 @@ subresource instead.
   resource (such as `book`) rather than `name` or `parent`.
   - The field **should** be [annotated as required][aip-203].
   - If the field represents the name of another resource, it **should**
-    identify the [resource type][aip-123] that it references.
+    identify the [resource type][aep-4] that it references.
 - A field for the value being added or removed **must** be included. It
   **should** be the singular name of the field.
   - The field **should** be [annotated as required][aip-203].
@@ -164,3 +164,5 @@ subresource instead.
   - The field **should** be designated as required.
 
 {% endtabs %}
+
+[aep-4]: ./0004.md

--- a/aep/general/0144/aep.md.j2
+++ b/aep/general/0144/aep.md.j2
@@ -3,7 +3,7 @@
 Within API, methods that operate on schemas containing arrays require
 consideration on the strategies for updating elements within the list.
 
-For larger arrays of resources, consider [pagination][/pagination].
+For larger arrays of resources, consider [pagination][aep-158].
 
 ## Guidance
 
@@ -62,7 +62,7 @@ array fields.
 ### Update strategies
 
 A resource **may** use one of two strategies to enable updating a array field:
-direct update using the [standard `Update`][aip-134] method, or custom `Add`
+direct update using the [standard `Update`][aep-134] method, or custom `Add`
 and `Remove` methods.
 
 A standard `Update` method has one key limitation: the user is only able to
@@ -70,9 +70,9 @@ update _the entire_ array. This means that the user is required to read the
 resource, make modifications to the array field value as needed, and send it
 back. This is fine for many situations, particularly when the array field is
 expected to have a small size (fewer than 10 or so) and race conditions are not
-an issue, or can be guarded against with [ETags][aip-154].
+an issue, or can be guarded against with [ETags][aep-154].
 
-**Note:** Declarative-friendly resources (AEP-128) **must** use the standard
+**Note:** Declarative-friendly resources **must** use the standard
 `Update` method, and not introduce `Add` and `Remove` methods. If declarative
 tools need to reason about particular relationships while ignoring others,
 consider using a subresource instead.
@@ -94,7 +94,7 @@ define custom methods using the verbs `Add` and `Remove`:
   of the RPC name **should** be the singular form of the field being added.
 - The response **should** be the resource itself, and **should** fully-populate
   the resource structure.
-- The HTTP method **must** be `POST`, as usual for [custom methods][aip-136].
+- The HTTP method **must** be `POST`, as usual for [custom methods][aep-136].
 - The HTTP URI **must** end with `:add*` or `:remove*`, where `*` is the
   camel-case singular name of the field being added or removed.
 - The request field receiving the resource name **should** map to the URI path.
@@ -122,7 +122,7 @@ define custom methods using the verbs `Add` and `Remove`:
   being added.
 - The response **should** be the resource itself, and **should** fully-populate
   the resource structure.
-- The HTTP method **must** be `POST`, as usual for [custom methods][aip-136].
+- The HTTP method **must** be `POST`, as usual for [custom methods][aep-136].
 - The HTTP URI **must** end with `:add*` or `:remove*`, where `*` is the
   camel-case singular name of the field being added or removed.
 - If the data being added in an `Add` operation is already present, the method
@@ -145,12 +145,12 @@ subresource instead.
 
 - A resource field **must** be included. It **should** be the name of the
   resource (such as `book`) rather than `name` or `parent`.
-  - The field **should** be [annotated as required][aip-203].
+  - The field **should** be [annotated as required][aep-203].
   - If the field represents the name of another resource, it **should**
     identify the [resource type][aep-4] that it references.
 - A field for the value being added or removed **must** be included. It
   **should** be the singular name of the field.
-  - The field **should** be [annotated as required][aip-203].
+  - The field **should** be [annotated as required][aep-203].
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AEP.
@@ -165,4 +165,3 @@ subresource instead.
 
 {% endtabs %}
 
-[aep-4]: ./0004.md

--- a/aep/general/0151/aep.md.j2
+++ b/aep/general/0151/aep.md.j2
@@ -37,7 +37,7 @@ Protocol buffer APIs **must** use the common component
 
 {% tab oas %}
 
-OpenAPI services **must** use this [`JSON Schema Operation`]JSON Schema
+OpenAPI services **must** use this [`JSON Schema Operation`][JSON Schema
 Operation] schema.
 
 {% endtabs %}

--- a/aep/general/0151/aep.md.j2
+++ b/aep/general/0151/aep.md.j2
@@ -58,15 +58,15 @@ The endpoint **must** return a `Operation` as described above.
 
 ### Standard methods
 
-APIs **may** return an `Operation` from the [`Create`][aip-133],
-[`Update`][aip-134], or [`Delete`][aip-135] standard methods if appropriate. In
+APIs **may** return an `Operation` from the [`Create`][aep-133],
+[`Update`][aep-134], or [`Delete`][aep-135] standard methods if appropriate. In
 this case, the `response` field **must** be the standard and expected response
 type for that standard method.
 
 When creating or deleting a resource with a long-running request, the resource
-**should** be included in [`List`][aip-132] and [`Get`][aip-131] calls;
+**should** be included in [`List`][aep-132] and [`Get`][aep-131] calls;
 however, the resource **should** indicate that it is not usable, generally with
-a [state enum][aip-216].
+a [state enum][aep-216].
 
 ### Parallel requests
 
@@ -90,7 +90,7 @@ has elapsed after the request completed.
 ### Errors
 
 Errors that prevent a long-running request from _starting_ **must** return an
-error response (AEP-193), similar to any other method.
+[error response][AEP-193], similar to any other method.
 
 Errors that occur over the course of a request **may** be placed in the
 metadata message. The errors themselves **must** still be represented with a
@@ -117,7 +117,7 @@ When using protocol buffers, the common component
   - If the response and metadata types are defined in another package, the
     fully-qualified message name **must** be used.
   - The response type **should not** be `google.protobuf.Empty` (except for
-    [`Delete`][aip-135] methods), unless it is certain that response data will
+    [`Delete`][aep-135] methods), unless it is certain that response data will
     _never_ be needed. If response data might be added in the future, define an
     empty message for the RPC response and use that.
   - The metadata type is used to provide information such as progress, partial

--- a/aep/general/0164/aep.md.j2
+++ b/aep/general/0164/aep.md.j2
@@ -38,7 +38,7 @@ A resource that supports soft delete **should** provide an `Undelete` method:
     resource itself.
 - A `name` field **must** be included in the request message; it **should** be
   called `name`.
-  - The field **should** be [annotated as required][aip-203].
+  - The field **should** be [annotated as required][aep-203].
   - The field **should** identify the [resource type][aep-4] that it
     references.
   - The comment for the field **should** document the resource pattern.

--- a/aep/general/0164/aep.md.j2
+++ b/aep/general/0164/aep.md.j2
@@ -39,7 +39,7 @@ A resource that supports soft delete **should** provide an `Undelete` method:
 - A `name` field **must** be included in the request message; it **should** be
   called `name`.
   - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] that it
+  - The field **should** identify the [resource type][aep-4] that it
     references.
   - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
@@ -127,3 +127,5 @@ resource is not deleted, the service **must** error with `409 Conflict`.
 - For long-running operations, see AEP-151.
 - For resource freshness validation (`etag`), see AEP-154.
 - For change validation (`validate_only`), see AEP-163.
+
+[aep-4]: ./0004.md

--- a/aep/general/130/aep.md.j2
+++ b/aep/general/130/aep.md.j2
@@ -70,7 +70,8 @@ likely have to be hand-written.
 [batch-update]: /batch-update
 [create]: /create
 [custom-methods]: /custom-methods
-[Declarative clients]: ./0009.md#declarative-clients
+[Declarative client]: ./0003.md#declarative-clients
+[Declarative clients]: ./0003.md#declarative-clients
 [delete]: /delete
 [get]: /get
 [list]: /list


### PR DESCRIPTION
I noticed a few dead links so decided to fix them.

Specifically:

- Replaced links to AIPs with links to the relevant AEP
- Fixed a few badly formatted links
- Migrated links from AEP-123 and AIP-123 to AEP-4. AIP-123 was [imported to AEP-4](https://github.com/aep-dev/aep.dev/pull/76/files) and the links were not all updated.
- Migrated links from AEP-9 and AIP-9 to AEP-3. AIP-9 was imported as AEP-3 and the links were not all updated.
- Removed the folder for AEP-9 as it is now just an empty shell.
- Fixed any broken links I noticed while doing the above work. I didn't comprehensively check the entire repository.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

💝 Thank you!
