### PR TITLE
fix(resource-types): remove uneeded resource type naming guidance

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -20,12 +20,6 @@ the following pattern: `{API Name}/{Type Name}`. The type name:
 - **must** Start with a lowercase letter.
 - **must** Be of the singular form of the noun.
 - **must** Use kebab case.
-- For Kubernetes, the type name when converted to UpperCamelCase **must** match
-  the [object][] name.
-- For OpenAPI, the type name when converted to UpperCamelCase **must** match
-  the name of the schema representing the object.
-- For protobuf, the type name when converted to UpperCamelCase **must** match
-  the name of the protobuf message.
 
 ### Examples
 


### PR DESCRIPTION
There's clauses around protobuf / kubernetes / openapi that are not relevant - this is already illustrated in the examples.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)