### PR TITLE
fix(lro): clarify protobuf response for no parallel requests

### DIFF
--- a/aep/general/0151/aep.md.j2
+++ b/aep/general/0151/aep.md.j2
@@ -75,10 +75,23 @@ but is not obligated to do so:
 
 - Resources that accept multiple parallel requests **may** place them in a
   queue rather than work on the requests simultaneously.
-- Resource that does not permit multiple requests in parallel (denying any new
-  request until the one that is in progress finishes) **must** return
-  `409 Conflict` if a user attempts a parallel request, and include an error
-  message explaining the situation.
+
+{% tab proto %}
+
+- A Resource that does not permit multiple requests in parallel (denying any new
+  request until the one that is in progress finishes) **must** return `ABORTED`
+  if a user attempts a parallel request, and include an error message explaining
+  the situation.
+
+{% tab oas %}
+
+- A Resource that does not permit multiple requests in parallel (denying any new
+  request until the one that is in progress finishes) **must** return a `409
+  Conflict` if a user attempts a parallel request, and include an error message
+  explaining the situation.
+
+{% endtabs %}
+
 
 ### Expiration
 


### PR DESCRIPTION
For protobuf guidance, it was unclear response code should be.

Partially addresses #224 

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)

