### PR TITLE
Make AEP-121 more generic

### DIFF
--- a/aep/general/0121/aep.md.j2
+++ b/aep/general/0121/aep.md.j2
@@ -1,6 +1,6 @@
 # Resource-oriented design
 
-Resource-oriented design is a pattern for specifying [RPC][] APIs, based on the
+Resource-oriented design is a pattern for specifying APIs, based on the
 following high-level design principles:
 
 - The fundamental building blocks of an API are individually-named _resources_
@@ -8,10 +8,6 @@ following high-level design principles:
 - A small number of standard _methods_ (verbs) provide the semantics for most
   common operations. However, custom methods are available in situations where
   the standard methods do not fit.
-
-Readers might notice similarities between these principles and some principles
-of [REST][]; resource-oriented design borrows many principles from REST, while
-also defining its own patterns where appropriate.
 
 ## Guidance
 
@@ -150,7 +146,6 @@ turn do not increase resource management complexity.
 [output only]: ./0203#output-only
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [resource references]: ./0122#fields-representing-another-resource
-[rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
 [singleton resources]: ./0156
 [soft delete]: ./0164
 [state]: ./0216

--- a/aep/general/0121/aep.yaml
+++ b/aep/general/0121/aep.yaml
@@ -3,5 +3,6 @@ id: 121
 state: approved
 slug: resources
 created: 2024-01-27
+order: 10
 placement:
   category: resources


### PR DESCRIPTION
AEP-121 has references to RPC APIs. Resource-oriented design isn't different between RPC + REST. I also changed the order, since this should be read first.