### PR TITLE
Remove forking encouragement

### DIFF
--- a/aep/general/0001/aep.md.j2
+++ b/aep/general/0001/aep.md.j2
@@ -23,18 +23,6 @@ API-related documentation, and the means by which service producers discuss and
 come to consensus on API guidance. AEPs are maintained as Markdown files with
 metadata in the AEP GitHub repository.
 
-## Adopting AEPs
-
-Companies **may** adopt the AEP system in one of two ways:
-
-- By applying the guidance described at [aep.dev][].
-- By "forking" the AEP system and setting up their own subdomain.
-
-Companies with an already-established corpus of services are unlikely to have
-exactly followed the guidance at [aep.dev][]. Forking the system is valuable
-because the guidance becomes comparable. Forks **must** retain the same
-numbering system AEP-2 to provide that comparability.
-
 ### Technical leadership
 
 The AEP system, as well as the guidance on [aep.dev][], is overseen by the AEP
@@ -56,9 +44,6 @@ sentence structure, markup, etc.).
 
 Committee membership is by invitation of the current committee. The committee
 **must not** include more than two members from the same company.
-
-**Note:** Companies that maintain their own fork of [aep.dev][] select their
-own leadership and have full control of their fork's content.
 
 ## States
 


### PR DESCRIPTION
The AIPs encouraged companies to fork the AIPs. Forking the AEPs dillutes our ability to build clients and build an ecosystem. We obviously can't stop companies from forking us, but we shouldn't encourage it.