### PR TITLE
integrate aep-openapi-linter into build process

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,7 @@ set -x
 export AEP_LOCATION="${PWD}"
 export SG_DIRECTORY="/tmp/site-generator"
 export AEP_LINTER_LOC="${SG_DIRECTORY}/api-linter"
+export AEP_OPENAPI_LINTER_LOC="${SG_DIRECTORY}/aep-openapi-linter"
 if [ ! -d "${SG_DIRECTORY}" ]; then
     git clone https://github.com/aep-dev/site-generator.git "${SG_DIRECTORY}"
 fi
@@ -10,9 +11,15 @@ fi
 if [ ! -d "${AEP_LINTER_LOC}" ]; then
     git clone https://github.com/aep-dev/api-linter.git "${AEP_LINTER_LOC}"
 fi
+
+if [ ! -d "${AEP_OPENAPI_LINTER_LOC}" ]; then
+    git clone https://github.com/aep-dev/aep-openapi-linter.git "${AEP_OPENAPI_LINTER_LOC}"
+fi
+
 cd "${SG_DIRECTORY}" || exit
 # make rules / website folder
 mkdir -p src/content/docs/tooling/linter/rules
+mkdir -p src/content/docs/tooling/openapi-linter/rules
 mkdir -p src/content/docs/tooling/website
 npm install
 npx playwright install --with-deps chromium


### PR DESCRIPTION
Integrates the `aep-openapi-linter` repository into the aeps build process to enable OpenAPI linter documentation on aep.dev.

  This is **Phase 2** of the OpenAPI linter integration, completing the work started in aep-dev/site-generator#87.

  ### Changes
  - Add `AEP_OPENAPI_LINTER_LOC` environment variable in `scripts/build.sh`
  - Clone `aep-openapi-linter` repository during build process
  - Create `src/content/docs/tooling/openapi-linter/rules/` directory

  ### Testing
  ✅ **Local build test**: Script successfully clones repositories and builds site
  ✅ **Generated files**: Verified 12 rule pages created in correct location
  ✅ **Local preview**: Confirmed navigation structure and page rendering at localhost:4321

### Note
  The Tooling section currently displays in this order: Protobuf Linter, Website, OpenAPI Linter. Alphabetical ordering can be addressed in a follow-up PR if desired.
  
  ### Dependencies
  **Requires**: aep-dev/site-generator#87 (merged 2025-10-14 ✅)

  Closes #361

  ## 🍱 Types of changes

  What types of changes does your code introduce to AEP? _Put an `x` in the boxes that apply_

  - [x] Enhancement
  - [ ] [New proposal](https://aep.dev/1#workflow)
  - [ ] Migrated from google.aip.dev
  - [ ] Chore / Quick Fix

  ## 📋 Your checklist for this pull request

  Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for contributing to this repository.

  ### General

  - [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
  - [x] Ensure that your PR [references AEPs](https://aep.dev/style-guide#referencing-aeps) correctly.
  - [x] [My code has been formatted](https://aep.dev/contributing#formatting) (usually `prettier -w .`)
  - [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

  💝 Thank you!
