### PR TITLE
fix(126): proto enum should prefix format

### DIFF
--- a/aep/general/0126/enum.proto
+++ b/aep/general/0126/enum.proto
@@ -45,16 +45,16 @@ message Book {
     FORMAT_UNSPECIFIED = 0;
 
     // The printed format, in hardback.
-    HARDBACK = 1;
+    FORMAT_HARDBACK = 1;
 
     // The printed format, in paperback.
-    PAPERBACK = 2;
+    FORMAT_PAPERBACK = 2;
 
     // An electronic book format.
-    EBOOK = 3;
+    FORMAT_EBOOK = 3;
 
     // An audio recording.
-    AUDIOBOOK = 4;
+    FORMAT_AUDIOBOOK = 4;
   }
 
   // The format of the book.


### PR DESCRIPTION
Aligning with protobuf best practices and the buf linter, proto enums should be prefixed with the enum name.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
