### PR TITLE
URL Only Fields should be `url` not `uri`.

### DIFF
--- a/aep/general/0140/aep.md.j2
+++ b/aep/general/0140/aep.md.j2
@@ -158,9 +158,55 @@ profile_image_bytes:
 
 ### URIs
 
-Field names representing URLs or URIs **should** always use `uri` rather than
-`url`. This is because while all URLs are URIs, not all URIs are URLs. Field
-names **may** use a prefix in front of `uri` as appropriate.
+Field names representing arbitrary URIs **should** use `uri`. In particular,
+note that URLs are URIs but not all URIs are URLs.
+
+Field names that can only represent a URL **should** use `url`.
+
+Field names **may** use a prefix in front of `uri` or `url` as appropriate.
+
+{% tab proto %}
+
+```proto
+message Book {
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  // A URL pointing to an image of the book.
+  string image_url = 2;
+  // A URI identifying the book.
+  // This could be an ISBN or a URL.
+  string uri = 3;
+}
+```
+
+{% tab oas %}
+
+```json
+{
+  "components": {
+    "schemas": {
+      "book": {
+        "properties": {
+          "image_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URL pointing to an image of the book."
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URI identifying the book. This could be an ISBN or a URL."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+{% endtabs %}
+
+**Note:** APIs that have previously used `uri` for URL fields may continue to
+do so to avoid unnecessary API changes and to preserve local consistency.
 
 ### Reserved words
 


### PR DESCRIPTION
Fixes #358 .

URL only fields should be named `url` not `uri`.

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [x] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [ ] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting) -> This doesn't exist?

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
