### PR TITLE
feat(137): specify HTTP status codes

### DIFF
--- a/aep/general/0137/aep.md.j2
+++ b/aep/general/0137/aep.md.j2
@@ -104,9 +104,14 @@ Apply methods implement a common request message pattern:
 
 {% sample '../example.proto', 'message Book' %}
 
+- If the resource is created or updated, the response **must** return `OK`.
+
 {% tab oas %}
 
 {% sample '../example.oas.yaml', '$.paths./publishers/{publisher_id}/books/{book_id}.put.responses.200' %}
+
+- If the resource is created, the response **must** return a `201` status code.
+- If the resource is updated, the response **must** return a `200` status code.
 
 {% endtabs %}
 


### PR DESCRIPTION
To adhere to RFC 9110, adding guidance around
the http response codes for PUT.

https://datatracker.ietf.org/doc/html/rfc9110#name-put

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [ ] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (usually `prettier -w .`)
- [x] [I have run `./scripts/fix.py`](https://aep.dev/contributing#formatting)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
