### PR TITLE
Change links in common components

### DIFF
--- a/aep/general/0213/aep.md.j2
+++ b/aep/general/0213/aep.md.j2
@@ -46,8 +46,8 @@ representations of the following concepts:
 
 ### API design patterns
 
-- [`Operation`][operation]: Represents the status of a long-running request (see AEP-151 for
-  details).
+- [`Operation`][operation]: Represents the status of a long-running request
+  (see AEP-151 for details).
 
 #### gRPC-specific API design patterns
 


### PR DESCRIPTION
AEP-213 references a whole bunch of common components that do not exist in AEP and has incorrect links for the others.

We should probably look to refactor this AEP to make it easier to read, but this gets us up-to-date.