### PR TITLE
Add OAS guidance for bytes fields (AEP-140)

### DIFF
--- a/aep/general/0140/aep.md.j2
+++ b/aep/general/0140/aep.md.j2
@@ -140,7 +140,19 @@ base64-encode a field into a `string` field.
 
 When sending binary data over the wire, the field name **should** be suffixed
 with "\_bytes". The contents of the field **should** be base64-encoded over the
-wire.
+wire. The field **should** be annotated with `contentEncoding: base64` and
+**may** include `contentMediaType` to specify the media type of the binary
+data.
+
+For example:
+
+```yaml
+profile_image_bytes:
+  type: string
+  contentEncoding: base64
+  contentMediaType: image/png
+  description: The user's profile image as a base64-encoded PNG.
+```
 
 {% endtabs %}
 


### PR DESCRIPTION
AEP-140 needs OAS guidance for bytes fields. The guidance I've chosen is attempting to best match the proto guidance.