### PR TITLE
Add OAS example for AEP-144

### DIFF
--- a/aep/general/0144/aep.md.j2
+++ b/aep/general/0144/aep.md.j2
@@ -26,7 +26,15 @@ message Book {
 
 {% tab oas %}
 
-**Note:** OAS guidance not yet written
+```yaml
+Book:
+  type: object
+  properties:
+    authors:
+      type: array
+      items:
+        type: string
+```
 
 {% endtabs %}
 


### PR DESCRIPTION
AEP-144 isn't missing guidance, but really missing an example.