### PR TITLE
fix(231): rename proto response field to results

### DIFF
--- a/aep/general/0231/aep.md.j2
+++ b/aep/general/0231/aep.md.j2
@@ -115,7 +115,7 @@ pattern:
 ```proto
 message BatchGetBooksResponse {
   // Books requested.
-  repeated Book books = 1;
+  repeated Book results = 1;
 }
 ```
 


### PR DESCRIPTION
Keeps the example in line with the latest guidance (field must be named results).