### PR TITLE
Examples for AEP-157 OAS

### DIFF
--- a/aep/general/0157/aep.md.j2
+++ b/aep/general/0157/aep.md.j2
@@ -21,7 +21,8 @@ named `read_mask`.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 
-List serialization / deserialization must conform to [RFC 9651](https://www.rfc-editor.org/rfc/rfc9651.html#name-serializing-a-list)
+List serialization / deserialization must conform to
+[RFC 9651](https://www.rfc-editor.org/rfc/rfc9651.html#name-serializing-a-list)
 
 **Note:** Changing the default value of `read_mask` is a
 [breaking change](./backwards-compatibility#semantic-changes).


### PR DESCRIPTION
AEP-157 is missing OAS examples. This will add them.