### PR TITLE
Move AEPs to approved state

### DIFF
--- a/aep/general/0001/aep.yaml
+++ b/aep/general/0001/aep.yaml
@@ -1,6 +1,6 @@
 ---
 id: 1
-state: reviewing
+state: approved
 created: 2020-10-05
 slug: purpose
 placement:

--- a/aep/general/0143/aep.yaml
+++ b/aep/general/0143/aep.yaml
@@ -1,6 +1,6 @@
 ---
 id: 143
-state: reviewing
+state: approved
 slug: standardized-codes
 created: 2023-01-22
 placement:

--- a/aep/general/0213/aep.yaml
+++ b/aep/general/0213/aep.yaml
@@ -1,6 +1,6 @@
 ---
 id: 213
-state: reviewing
+state: approved
 slug: common-components
 created: 2023-01-22
 placement:

--- a/aep/general/0214/aep.yaml
+++ b/aep/general/0214/aep.yaml
@@ -1,6 +1,6 @@
 ---
 id: 214
-state: reviewing
+state: approved
 slug: expiration
 created: 2024-03-14
 placement:


### PR DESCRIPTION
We've got a bunch of AEPs in the reviewing state.  I've moved the following (that have content) to approved. 

This keeps the Batch AEPs (minus Batch Get) in the reviewing state, since we're going to handle those eventually.

  Approved (changed state from reviewing to approved):
  - AEP 0001 (aep/general/0001/aep.yaml) - AEP Purpose and Guidelines
  - AEP 0143 (aep/general/0143/aep.yaml) - Standardized codes
  - AEP 0213 (aep/general/0213/aep.yaml) - Common components
  - AEP 0214 (aep/general/0214/aep.yaml) - Resource expiration
