### PR TITLE
feat(0004): clarify resource names requirements

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -71,33 +71,16 @@ For OpenAPI 3.0, Resources must be defined in `#components/schemas` and use the
 [`x-aep-resource`](https://aep.dev/json-schema/extensions/x-aep-resource.json)
 extension:
 
-```json
-{
-  "components": {
-    "schemas": {
-      "UserEvent": {
-        "type": "object",
-        "x-aep-resource": {
-          "type": "user.example.com/user-event",
-          "singular": "user-event",
-          "plural": "user-events",
-          "patterns": [
-            "projects/{project_id}/user-events/{user_event_id}",
-            "folder/{folder_id}/user-events/{user_event_id}",
-            "users/{user_id}/events/{user_event_id}"
-          ]
-        }
-      }
-    }
-  }
-}
-```
+{% sample '../example.oas.yaml', '$.components.schemas.book.x-aep-resource' %}
 
 {% endtabs %}
 
 - The `type` field **must** be the resource type `{API Name}/{Type Name}`
 - The `singular` field **must** be the kebab-case singular type name.
 - The `plural` field **must** be the kebab-case plural of the singular.
+- The `parent` field **must** be a list of all type names of parents of the
+  resource.
+  - If the resource has no parents, this field may be omitted.
 
 The `pattern` field **must** match the `pattern` rule in the following grammar,
 expressed as [EBNF][EBNF]:


### PR DESCRIPTION
A requirement stated that only alphanumerics were allowed, conflicting with a line later that also allowed kebab-cased  dashes.

Clarifying that dashes are indeed allowed.

fixes #396

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (run `make lint`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
