### PR TITLE
fix(102): slash, not backslash, in API name

### DIFF
--- a/aep/general/0102/aep.md.j2
+++ b/aep/general/0102/aep.md.j2
@@ -28,7 +28,8 @@ The API Name:
 - **must** only use valid domain name characters as specified in
   [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1), or a
   slash `[.-a-z0-9/]`)
-- **must** use all lower case.
+- **must** use all lowercase.
+- **must** start with a lowercase letter.
 - **should not** use path prefixes that could also be misconstrued as a
   resource collection (e.g. `apis.examples.com/users`)
 


### PR DESCRIPTION
The AEPs incorrectly used the term "backslash".

fixes #395

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (run `make lint`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
