### PR TITLE
update aep-136 to clarify usage of kebab-case in the method name. (#408)

### DIFF
--- a/aep/general/0136/aep.md.j2
+++ b/aep/general/0136/aep.md.j2
@@ -25,7 +25,8 @@ apply consistently:
 - The HTTP URI **must** use a `:` character followed by the custom verb
   (`:archive` in the above example), and the verb in the URI **must** match the
   verb in the name of the RPC.
-  - If word separation is required, `kebab-case` **must** be used.
+  - If word separation is required, `kebab-case` **must** be used (e.g.
+    `:translate-text`, not `:translateText`).
 - The name of the RPC **should** be a verb followed by a noun.
   - The name of the RPC **must not** contain prepositions ("for", "with",
     etc.).
@@ -106,7 +107,7 @@ permanent effect on data within the API.
 
 {% tab oas %}
 
-{% sample 'translate.oas.yaml', '$.paths./projects/{projectId}:translateText' %}
+{% sample 'translate.oas.yaml', '$.paths./projects/{project_id}:translate-text' %}
 
 {% endtabs %}
 
@@ -116,7 +117,8 @@ permanent effect on data within the API.
   used.
 - The URI **should** place both the verb and noun after the `:` separator
   (avoid a "faux collection key" in the URI in this case, as there is no
-  collection). For example, `:translateText` is preferable to `text:translate`.
+  collection). For example, `:translate-text` is preferable to
+  `text:translate`.
 - Stateless methods **must** use `POST` if they involve billing.
 
 ### Usage in declarative clients

--- a/aep/general/0136/translate.oas.yaml
+++ b/aep/general/0136/translate.oas.yaml
@@ -4,7 +4,7 @@ info:
   title: Library
   version: 1.0.0
 paths:
-  /projects/{projectId}:translateText:
+  /projects/{project_id}:translate-text:
     post:
       operationId: translateText
       description: Translates the provided text from one language to another.
@@ -37,7 +37,7 @@ paths:
             application/json:
               schema:
                 description: |
-                  Response structure for the translateText operation.
+                  Response structure for the translate-text operation.
                 properties:
                   translated_text:
                     type: string

--- a/aep/general/0136/translate.proto
+++ b/aep/general/0136/translate.proto
@@ -22,7 +22,7 @@ service Translate {
   // Translates the provided text from one language to another.
   rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
     option (google.api.http) = {
-      post: "/v1/{project=projects/*}:translateText"
+      post: "/v1/{project=projects/*}:translate-text"
       body: "*"
     };
   }


### PR DESCRIPTION
Closes #408

## Summary

Clarifies that custom method URIs must use kebab-case and fixes the Stateless Methods examples in AEP-136 that incorrectly used camelCase (`:translateText` → `:translate-text`).

## Changes

- Added an explicit example to the guidance section showing kebab-case vs camelCase (`:translate-text`, not `:translateText`)
- Fixed `translate.oas.yaml` path: `/projects/{projectId}:translateText` → `:translate-text`
- Fixed `translate.proto` HTTP annotation: `:translateText` → `:translate-text`
- Updated the Stateless Methods prose to reference `:translate-text` instead of `:translateText`

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [ ] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (run `make lint`)

<!-- uncomment this if PR is for a new AEP

### Additional checklist for a new AEP

- [ ] A new AEP **should** be no more than two pages if printed out.
- [ ] Ensure that the PR is editable by maintainers.
- [ ] Ensure that [File structure](https://aep.dev/style-guide#file-structure)
      guidelines are met.
- [ ] Ensure that
      [Document structure](https://aep.dev/style-guide#document-structure)
      guidelines are met.

-->

💝 Thank you!
