### PR TITLE
fix(0004): use snake case for pattern variable

### DIFF
--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -91,7 +91,7 @@ element = variable | literal;
 variable = "{", literal, "}";
 ```
 
-Where `literal` matches the regex `[a-z][a-z0-9\-_]*[a-z0-9]`.
+Where `literal` matches the regex `[a-z][a-z0-9_]*[a-z0-9]`.
 
 - Patterns **must** match the possible [paths](/paths) of the resource.
 - Pattern variables (the segments within braces) **must** match the singular of

--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -96,7 +96,7 @@ Where `literal` matches the regex `[a-z](?:[a-z0-9\-_]*[a-z0-9])?`.
 - Patterns **must** match the possible [paths](/paths) of the resource.
 - Pattern variables (the segments within braces) **must** match the singular of
   the resource whose id is being matched by that value, suffixed with `_id`.
-- Pattern variables (the segments within braces) **must** muse snake case.
+- Pattern variables (the segments within braces) **must** use snake case.
 
 #### Pattern uniqueness
 

--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -91,11 +91,12 @@ element = variable | literal;
 variable = "{", literal, "}";
 ```
 
-Where `literal` matches the regex `[a-z][a-z0-9_]*[a-z0-9]`.
+Where `literal` matches the regex `[a-z](?:[a-z0-9\-_]*[a-z0-9])?`.
 
 - Patterns **must** match the possible [paths](/paths) of the resource.
 - Pattern variables (the segments within braces) **must** match the singular of
   the resource whose id is being matched by that value, suffixed with `_id`.
+- Pattern variables (the segments within braces) **must** muse snake case.
 
 #### Pattern uniqueness
 

--- a/aep/general/0004/aep.md.j2
+++ b/aep/general/0004/aep.md.j2
@@ -58,7 +58,7 @@ message UserEvent {
     plural: "user-events"
     // define one or more patterns, e.g. if a resource has more than one parent.
     pattern: "projects/{project_id}/user-events/{user_event_id}"
-    pattern: "folder/{folder_id}/user-events/{user_event_d}"
+    pattern: "folder/{folder_id}/user-events/{user_event_id}"
     pattern: "users/{user_id}/events/{user_event_id}"
   };
 


### PR DESCRIPTION
* fix the literal regex to support 1-character segments
* add rule to use snake case on pattern variables
* typo on one of the example

## 🍱 Types of changes

What types of changes does your code introduce to AEP? _Put an `x` in the boxes
that apply_

- [x] Enhancement
- [ ] [New proposal](https://aep.dev/1#workflow)
- [ ] Migrated from google.aip.dev
- [x] Chore / Quick Fix

## 📋 Your checklist for this pull request

Please review the [AEP Style and Guidance](https://aep.dev/style-guide) for
contributing to this repository.

### General

- [x] Basic [Guidance](https://aep.dev/style-guide#guidance) is met.
- [x] Ensure that your PR
      [references AEPs](https://aep.dev/style-guide#referencing-aeps)
      correctly.
- [x] [My code has been formatted](https://aep.dev/contributing#formatting)
      (run `make lint`)
